### PR TITLE
chore: Add synchronization for CP4BA

### DIFF
--- a/config/cloudpaks/cp4a/operators/templates/07-operators/99-postsync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/07-operators/99-postsync-check-all-csvs.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-aiops-csvs
+  name: check-cp4a-csvs
   annotations:
     argocd.argoproj.io/hook: PostSync
   namespace: openshift-gitops
@@ -22,7 +22,7 @@ spec:
               cpu: "500m"
           env:
             - name: TARGET_NAMESPACE
-              value: "{{.Values.metadata.argocd_app_namespace}}"
+              value: "{{.Values.argocd_app_namespace}}"
             - name: WAIT_TIME
               value: "{{.Values.metadata.post_install_wait}}"
           command:
@@ -38,7 +38,8 @@ spec:
               operation_limit_seconds=$(( $(date +%s) + 2400 ))
               csv_installing=0
               while [ ${current_seconds} -lt ${operation_limit_seconds} ]; do
-                if [ $(oc get csv -A | grep -vc Succeeded) -gt 1 ]; then
+                if [ $(oc get csv -n "${TARGET_NAMESPACE}" | grep -vc Succeeded) -gt 1 ] || \
+                   [ $(oc get csv -n ibm-common-services | grep -vc Succeeded) -gt 1 ]; then
                   csv_installing=1
                   echo "INFO: CSVs still installing."
                   sleep 60
@@ -48,6 +49,9 @@ spec:
                 fi
                 current_seconds=$(( $(date +%s) ))
               done
+
+              oc get csv -n "${TARGET_NAMESPACE}"
+              oc get csv -n ibm-common-services
 
               if [ ${csv_installing} -eq 0 ]; then
                 echo "INFO: All CSVs are ready."

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/99-postsync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/99-postsync-check-all-csvs.yaml
@@ -44,6 +44,7 @@ spec:
                   echo "INFO: CSVs still installing."
                   sleep 60
                 else
+                  csv_installing=0
                   break
                 fi
                 current_seconds=$(( $(date +%s) ))


### PR DESCRIPTION
Closes: #24

Description of changes:
- Wait for CSVs to succeed after synchronizing the `cp4a-operators` application.
- Applying a small fix to the same sync point in the `cp4i-operators` and `cp4aiops-operators` applications (found while validating this PR)

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

