### PR TITLE
chore: Update CP4BA with 21.0.3 fixpack

### DIFF
--- a/config/cloudpaks/cp4a/operators/templates/07-operators/base-operator.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/07-operators/base-operator.yaml
@@ -13,4 +13,4 @@ spec:
   name: ibm-cp4a-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-cp4a-operator.v21.2.2
+  startingCSV: ibm-cp4a-operator.v21.2.3

--- a/config/cloudpaks/cp4a/resources/templates/00-presync-patch-db2-sts.yaml
+++ b/config/cloudpaks/cp4a/resources/templates/00-presync-patch-db2-sts.yaml
@@ -10,8 +10,9 @@ metadata:
   # while the ICP4ACluster resource is being applied. If you make it a presync hook, then
   # the ICP4Cluster resource waits indefinitely. If you make it a postsync hook, it never
   # runs because the ICP4Cluster resource never becomes healthy.
-  # Ultimately, this job need to be in the exct same sync-wave as ICP4ACluster
+  # Ultimately, this job needs to be in the same sync-wave as ICP4ACluster
   annotations:
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-wave: "201"
   name: cp4a-patch-db2-sts
   namespace: openshift-gitops

--- a/config/cloudpaks/cp4a/resources/templates/icp4a-cluster.yaml
+++ b/config/cloudpaks/cp4a/resources/templates/icp4a-cluster.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   olm_ent_workflow: false
   olm_ent_option_bai: false
-  olm_demo_application: false
+  olm_demo_application: true
   olm_deployment_type: demo
   olm_ent_decisions_ads: false
   olm_ent_option_adp:
@@ -67,6 +67,11 @@ spec:
             dc_os_xa_datasource_name: AWSINS1DOCSXA
           oc_cpe_obj_store_display_name: AWSINS1DOCS
           oc_cpe_obj_store_symb_name: AWSINS1DOCS
+        - oc_cpe_obj_store_conn:
+            dc_os_datasource_name: AEOS
+            dc_os_xa_datasource_name: AEOSXA
+          oc_cpe_obj_store_display_name: AEOS
+          oc_cpe_obj_store_symb_name: AEOS
   olm_ent_option_application:
     app_designer: false
   olm_ent_option_ads:
@@ -191,6 +196,20 @@ spec:
         database_ssl_secret_name: ''
         dc_common_os_datasource_name: BAWDOS
         dc_common_os_xa_datasource_name: BAWDOSXA
+        dc_database_type: db2
+        dc_hadr_max_retries_for_client_reroute: 3
+        dc_hadr_retry_interval_for_client_reroute: 15
+        dc_hadr_standby_port: ''
+        dc_hadr_standby_servername: ''
+        dc_hadr_validation_timeout: 15
+        dc_oracle_os_jdbc_url: ''
+        dc_os_label: ''
+      - database_name: ''
+        database_port: ''
+        database_servername: ''
+        database_ssl_secret_name: ''
+        dc_common_os_datasource_name: BAWTOS
+        dc_common_os_xa_datasource_name: BAWTOSXA
         dc_database_type: db2
         dc_hadr_max_retries_for_client_reroute: 3
         dc_hadr_retry_interval_for_client_reroute: 15


### PR DESCRIPTION
Contributes to: #26

Description of changes:
- Update starting CSV for operators
- Update ICP4ACluster to match default YAML

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

Clean installation: 

```
argocd app list -l app.kubernetes.io/instance=cp4a-app
NAME            CLUSTER                         NAMESPACE      PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                             TARGET
cp4a-app        https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a     26-cp4a-update
cp4a-operators  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators  26-cp4a-update
cp4a-resources  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources  26-cp4a-update
r
```