### PR TITLE
chore: Reverse olm_demo_application change

### DIFF
--- a/config/cloudpaks/cp4a/resources/templates/icp4a-cluster.yaml
+++ b/config/cloudpaks/cp4a/resources/templates/icp4a-cluster.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   olm_ent_workflow: false
   olm_ent_option_bai: false
-  olm_demo_application: true
+  olm_demo_application: false
   olm_deployment_type: demo
   olm_ent_decisions_ads: false
   olm_ent_option_adp:


### PR DESCRIPTION
Closes: #26 

Description of changes:
- Reverse change to BAA deployment. It should was set to false and should be kept that way. Context: https://www.ibm.com/docs/en/cloud-paks/1.0?topic=hub-advanced-configuration-business-automation-application

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-ga                                   main
cicd-app                https://kubernetes.default.svc  cicd              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp-shared                  main
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp-shared/operators               
cp4a-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp4a                       
cp4a-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4a/operators                    
cp4a-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4a/resources                    26-cp4a-update-2
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  
dev-env                 https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/sbo                                         
stage-env               https://kubernetes.default.svc  stage             default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    
```