### PR TITLE
bug: Handle missing kn-cli service

### DIFF
--- a/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/9999-postsync-close-route.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/9999-postsync-close-route.yaml
@@ -26,10 +26,16 @@ spec:
               set -eo pipefail
               set -x
 
-              oc annotate service.serving.knative.dev/kn-cli \
+              oc get service.serving.knative.dev/kn-cli \
                 -n knative-serving \
-                --overwrite=true \
-                serving.knative.openshift.io/disableRoute=true
+              && {
+                oc annotate service.serving.knative.dev/kn-cli \
+                  -n knative-serving \
+                  --overwrite=true \
+                  serving.knative.openshift.io/disableRoute=true \
+                || exit 1
+              }  \
+              || echo "INFO: kn-cli service was not present."
 
       restartPolicy: Never
       serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}


### PR DESCRIPTION
Closes: #30 

Description of changes:
- <change 1 ... >
- <change 2 ... >

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

![image](https://user-images.githubusercontent.com/3278623/134566864-f9271fbe-1574-4d49-850f-cdc0f75f8147.png)

Pod logs:

Evidence of new block of code taking the expected approach of not exiting with an error if the route does not exist:

```
W
+ oc get service.serving.knative.dev/kn-cli -n knative-serving
I0923 17:16:30.254180       7 request.go:665] Waited for 1.002146047s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/autosc
aling/v2beta1?timeout=32s
I0923 17:16:40.454247       7 request.go:665] Waited for 11.202048999s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/opera
tors.coreos.com/v1?timeout=32s
I0923 17:16:50.654194       7 request.go:665] Waited for 21.401895272s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/ingre
ss.operator.openshift.io/v1?timeout=32s
Error from server (NotFound): services.serving.knative.dev "kn-cli" not found
+ echo 'INFO: kn-cli service was not present.'
INFO: kn-cli service was not present.
```

Successful status of Argo resources:

```
argocd app list -l app.kubernetes.io/instance=cp4aiops-app
NAME                CLUSTER                         NAMESPACE      PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                 TARGET
cp4aiops-app        https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops     30-aiops-knative-postsync
cp4aiops-operators  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators  30-aiops-knative-postsync
cp4aiops-resources  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources  30-aiops-knative-postsync
```