### PR TITLE
Update catalogsource-ibm-cs.yaml

### DIFF
--- a/config/cloudpaks/cp-shared/operators/templates/catalogsource-ibm-cs.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/catalogsource-ibm-cs.yaml
@@ -10,7 +10,7 @@ spec:
   displayName: IBMCS Operators
   publisher: IBM
   sourceType: grpc
-  image: docker.io/ibmcom/ibm-common-service-catalog:3.8.0
+  image: docker.io/ibmcom/ibm-common-service-catalog:latest
   updateStrategy:
     registryPoll:
       interval: 45m


### PR DESCRIPTION
Use latest service catalog.

Description of changes:
- The catalog should always reference the latest version.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

