### PR TITLE
chore: Default to OpenShift GitOps GA account

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ Making changes to this repository requires a working knowledge of Argo CD admini
     argocd app set <app-name> \
         --repo <url-fork-or-clone> \
         --revision <branch-in-repo> \
-        --helm-set repoURL=<url-fork-or-clone>
+        --helm-set repoURL=<url-fork-or-clone> \
+        --helm-set targetRevisiton=<branch-in-repo>
     ```
 
     For instance, assuming you cloned this repo into https://github.com/nastacio/cloudpak-gitops, and you wanted to make changes to the `cp4i-app` Application in a branch named `new-feature`, you would run the command like this:
@@ -29,7 +30,8 @@ Making changes to this repository requires a working knowledge of Argo CD admini
     argocd app set cp4i-app \
         --repo https://github.com/nastacio/cloudpak-gitops \
         --revision new-feature \
-        --helm-set repoURL=https://github.com/nastacio/cloudpak-gitops
+        --helm-set repoURL=https://github.com/nastacio/cloudpak-gitops \
+        --helm-set targetRevisiton=new-feature
     ```
 
     Since the application has an automated synchronization policy, the synchronization with the new repository and branch would start immediately.

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -2,7 +2,7 @@
 repoURL: https://github.com/IBM/cloudpak-gitops
 targetRevision: main
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops

--- a/config/argocd-cloudpaks/cp4a/values.yaml
+++ b/config/argocd-cloudpaks/cp4a/values.yaml
@@ -2,7 +2,7 @@
 repoURL: https://github.com/IBM/cloudpak-gitops
 targetRevision: main
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops

--- a/config/argocd-cloudpaks/cp4aiops/values.yaml
+++ b/config/argocd-cloudpaks/cp4aiops/values.yaml
@@ -2,7 +2,7 @@
 repoURL: https://github.com/IBM/cloudpak-gitops
 targetRevision: main
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops

--- a/config/argocd-cloudpaks/cp4i/values.yaml
+++ b/config/argocd-cloudpaks/cp4i/values.yaml
@@ -2,7 +2,7 @@
 repoURL: https://github.com/IBM/cloudpak-gitops
 targetRevision: main
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops

--- a/config/cloudpaks/cp4a/operators/values.yaml
+++ b/config/cloudpaks/cp4a/operators/values.yaml
@@ -2,4 +2,4 @@
 metadata:
   individual_namespace: cp4a
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller

--- a/config/cloudpaks/cp4a/resources/values.yaml
+++ b/config/cloudpaks/cp4a/resources/values.yaml
@@ -1,6 +1,6 @@
 ---
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
 spec:

--- a/config/cloudpaks/cp4aiops/operators/values.yaml
+++ b/config/cloudpaks/cp4aiops/operators/values.yaml
@@ -3,4 +3,4 @@ metadata:
   argocd_app_namespace: ibm-cloudpaks
   individual_namespace: ibm-cloudpaks
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller

--- a/config/cloudpaks/cp4aiops/resources/values.yaml
+++ b/config/cloudpaks/cp4aiops/resources/values.yaml
@@ -1,6 +1,6 @@
 ---
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   post_install_wait: 2h

--- a/config/cloudpaks/cp4i/operators/values.yaml
+++ b/config/cloudpaks/cp4i/operators/values.yaml
@@ -2,3 +2,5 @@
 metadata:
   argocd_namespace: openshift-gitops
   individual_namespace: cp4i
+serviceaccount:
+  argocd_application_controller: openshift-gitops-argocd-application-controller

--- a/config/cloudpaks/cp4i/resources/values.yaml
+++ b/config/cloudpaks/cp4i/resources/values.yaml
@@ -1,6 +1,6 @@
 ---
 serviceaccount:
-  argocd_application_controller: argocd-cluster-argocd-application-controller
+  argocd_application_controller: openshift-gitops-argocd-application-controller
 metadata:
   argocd_namespace: openshift-gitops
 storageclass:

--- a/docs/install.md
+++ b/docs/install.md
@@ -136,6 +136,8 @@ After completing the list of activities listed in the previous sections, you hav
     | Revision | HEAD |
     | Cluster URL | https://kubernetes.default.svc |
 
+1. Under "Parameters", if using OCP 4.6, replace the value of the field `serviceaccount.argocd_application_controller` with the value `openshift-gitops-argocd-application-controller`
+
 1. After filling out the form details, click the "Create" button
 
 1. (add actual Cloud Pak) Click on the "New App+" button again and fill out the form with values matching the Cloud Pak of your choice, according to the table below:
@@ -159,7 +161,7 @@ After completing the list of activities listed in the previous sections, you hav
 
 1. After filling out the form details, click the "Create" button
 
-1. Under "Parameters", if using OCP 4.7 or later, replace the value of the field `serviceaccount.argocd_application_controller` with the value `openshift-gitops-argocd-application-controller`
+1. Under "Parameters", if using OCP 4.6, replace the value of the field `serviceaccount.argocd_application_controller` with the value `argocd-cluster-argocd-application-controller`
 
 1. Still under "Parameters", set the values for the fields `storageclass.rwo` and `storageclass.rwx` with the appropriate storage classes. For OpenShift Container Storage, the values will be `ocs-storagecluster-ceph-rbd` and `ocs-storagecluster-cephfs`, respectively.
 

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -32,27 +32,21 @@ These steps assume you  logged in to the OCP server with the `oc` command-line i
    argo_route=argocd-cluster-server
    argo_secret=argocd-cluster-cluster
    sa_account=argocd-cluster-argocd-application-controller
-
-   argo_pwd=$(oc get secret ${argo_secret} \
-               -n openshift-gitops \
-               -o jsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
-   && argo_url=$(oc get route ${argo_route} \
-                  -n openshift-gitops \
-                  -o jsonpath='{.spec.host}') \
-   && argocd login "${argo_url}" \
-         --username admin \
-         --password "${argo_pwd}" \
-         --insecure
    ```
 
-   Using OCP 4.7 and later (the object names change a little from OCP 4.6:)
+   Using OCP 4.7 and later:
 
    ```sh
    # OCP 4.7+
    argo_route=openshift-gitops-server
    argo_secret=openshift-gitops-cluster
    sa_account=openshift-gitops-argocd-application-controller
+   ```
 
+1. Add the Argo application:
+
+   ```sh
+   #  Tthis step assumes you still have the shell variables assigned from previous actions
    argo_pwd=$(oc get secret ${argo_secret} \
                -n openshift-gitops \
                -o jsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
@@ -61,13 +55,8 @@ These steps assume you  logged in to the OCP server with the `oc` command-line i
                   -o jsonpath='{.spec.host}') \
    && argocd login "${argo_url}" \
          --username admin \
-         --password "${argo_pwd}" \
-         --insecure
-   ```
+         --password "${argo_pwd}"
 
-1. Add the Argo application. (this step assumes you still have the shell variables assigned from previous actions) :
-
-   ```sh
    argocd app create rhacm-app \
          --project default \
          --dest-namespace openshift-gitops \


### PR DESCRIPTION
Closes: #35

Description of changes:
- Changes the default GitOps service account name to the one used in OpenShift GitOps GA

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-ga                                   35-gitops-ga
cicd-app                https://kubernetes.default.svc  cicd              default  OutOfSync  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            35-gitops-ga
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared                  35-gitops-ga
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators               35-gitops-ga
cp4a-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a                       35-gitops-ga
cp4a-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators                    35-gitops-ga
cp4a-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources                    35-gitops-ga
cp4aiops-app            https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops                   35-gitops-ga
cp4aiops-operators      https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators                35-gitops-ga
cp4aiops-resources      https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources                35-gitops-ga
cp4i-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i                       main
cp4i-client             https://kubernetes.default.svc  dev               default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              35-gitops-ga
cp4i-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/operators                    main
cp4i-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/resources                    main
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  35-gitops-ga
dev-env                 https://kubernetes.default.svc  dev               default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      35-gitops-ga
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/sbo                                         35-gitops-ga
stage-env               https://kubernetes.default.svc  stage             default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    35-gitops-ga
```

Note: There is something off with the cp4i-app, which refuses the setting of an alternate branch. That is outside the scope of this PR, so I will open an issue for it.
