### PR TITLE
chore: Remove startingCSV fields

### DIFF
--- a/config/cloudpaks/cp4a/operators/templates/07-operators/base-operator.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/07-operators/base-operator.yaml
@@ -13,4 +13,3 @@ spec:
   name: ibm-cp4a-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-cp4a-operator.v21.2.3

--- a/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/0002-serverless.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/0002-serverless.yaml
@@ -17,4 +17,3 @@ spec:
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: serverless-operator.v1.16.0

--- a/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/0005-strimzi.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/00-prereqs/0005-strimzi.yaml
@@ -15,4 +15,3 @@ spec:
   name: strimzi-kafka-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: strimzi-cluster-operator.v0.19.0

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/apic.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/apic.yaml
@@ -13,4 +13,3 @@ spec:
   name: ibm-apiconnect
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-apiconnect.v2.3.0

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/mq.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/mq.yaml
@@ -13,4 +13,3 @@ spec:
   name: ibm-mq
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-mq.v1.5.0

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/platform-navigator.yaml
@@ -16,4 +16,3 @@ spec:
   name: ibm-integration-platform-navigator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  startingCSV: ibm-integration-platform-navigator.v5.0.0

--- a/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
+++ b/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
@@ -13,4 +13,3 @@ spec:
   name: advanced-cluster-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: advanced-cluster-management.v2.3.3

--- a/config/rhacm/seeds/templates/0200-policy-openshift-gitops-preview.yaml
+++ b/config/rhacm/seeds/templates/0200-policy-openshift-gitops-preview.yaml
@@ -42,4 +42,3 @@ spec:
                   name: openshift-gitops-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
-                  startingCSV: openshift-gitops-operator.v1.0.0

--- a/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
+++ b/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
@@ -42,7 +42,6 @@ spec:
                   name: openshift-gitops-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
-                  startingCSV: openshift-gitops-operator.v1.3.0
             - complianceType: musthave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
@@ -56,4 +55,3 @@ spec:
                   name: openshift-pipelines-operator-rh
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
-                  startingCSV: redhat-openshift-pipelines.v1.4.1

--- a/config/sbo/templates/sbo-operator.yaml
+++ b/config/sbo/templates/sbo-operator.yaml
@@ -7,9 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "100"
 spec:
-  channel: beta
+  channel: stable
   installPlanApproval: Automatic
   name: rh-service-binding-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: service-binding-operator.v0.9.1


### PR DESCRIPTION
Closes: #42

Description of changes:
- Remove all occurrences of `startingCSV` in `Subscription` CRs.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
```

On a 4.8.x custer:
![image](https://user-images.githubusercontent.com/3278623/139142999-61c31642-8459-4acc-b3c3-5a4e35dc8b89.png)

