### PR TITLE
fix: Match newest event listener format

### DIFF
--- a/config/cicd/base/09-routes/gitops-webhook-event-listener.yaml
+++ b/config/cicd/base/09-routes/gitops-webhook-event-listener.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   host: ""
   port:
-    targetPort: 8080
+    targetPort: http-listener
   to:
     kind: Service
     name: el-cicd-event-listener

--- a/config/cicd/overlays-ga/cicd-event-listener.yaml
+++ b/config/cicd/overlays-ga/cicd-event-listener.yaml
@@ -14,15 +14,27 @@ spec:
         - kind: TriggerBinding
           ref: github-push-binding
       interceptors:
-        - github:
-            secretRef:
-              secretKey: webhook-secret-key
-              secretName: gitops-webhook-secret
-        - cel:
-            filter: (header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'cloudpakbringup/gitops')
-            overlays:
-              - expression: body.ref.split('/')[2]
-                key: ref
+        - params:
+            - name: secretRef
+              value:
+                secretKey: webhook-secret-key
+                secretName: gitops-webhook-secret
+            - name: eventTypes
+          ref:
+            kind: ClusterInterceptor
+            name: github
+        - params:
+            - name: filter
+              value: >-
+                (header.match('X-GitHub-Event', 'push') &&
+                body.repository.full_name == 'cloudpakbringup/gitops')
+            - name: overlays
+              value:
+                - expression: 'body.ref.split(''/'')[2]'
+                  key: ref
+          ref:
+            kind: ClusterInterceptor
+            name: cel
       name: ci-dryrun-from-push
       template:
         ref: ci-dryrun-from-push-template
@@ -32,15 +44,27 @@ spec:
         - kind: TriggerBinding
           ref: github-push-binding
       interceptors:
-        - github:
-            secretRef:
-              secretKey: webhook-secret-key
-              secretName: webhook-secret-dev-gitops-service
-        - cel:
-            filter: (header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'nastacio/mq-dev-patterns')
-            overlays:
-              - expression: body.ref.split('/')[2]
-                key: ref
+        - params:
+            - name: secretRef
+              value:
+                secretKey: webhook-secret-key
+                secretName: webhook-secret-dev-gitops-service
+            - name: eventTypes
+          ref:
+            kind: ClusterInterceptor
+            name: github
+        - params:
+            - name: filter
+              value: >-
+                (header.match('X-GitHub-Event', 'push') &&
+                body.repository.full_name == 'nastacio/mq-dev-patterns')
+            - name: overlays
+              value:
+                - expression: 'body.ref.split(''/'')[2]'
+                  key: ref
+          ref:
+            kind: ClusterInterceptor
+            name: cel
       name: app-ci-build-from-push-gitops-service
       template:
         ref: app-ci-template


### PR DESCRIPTION
Closes: #45

Description of changes:
- Match new EventListener format introduced in recent OpenShift Pipeline operator changes

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list -l app.kubernetes.io/instance=argo-app
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                                   45-fix-cicd
cicd-app                https://kubernetes.default.svc  cicd              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            45-fix-cicd
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  main
dev-env                 https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      main
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/sbo                                         main
stage-env               https://kubernetes.default.svc  stage             default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    main
```
