### PR TITLE
Upgrades CP4I to 2021.3 release

### DIFF
--- a/config/cloudpaks/cp4i/operators/templates/04-operators/mq.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/mq.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ibm-mq-ibm-operator
   namespace: {{.Values.argocd_app_namespace}}
 spec:
-  channel: v1.5
+  channel: v1.6
   installPlanApproval: Automatic
   name: ibm-mq
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/platform-navigator.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     operators.coreos.com/ibm-integration-platform-navigator.ibm-cloudpaks: ''
 spec:
-  channel: v5.0
+  channel: v5.1
   installPlanApproval: Automatic
   name: ibm-integration-platform-navigator
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4i/resources/templates/05-crds/api-connect.yaml
+++ b/config/cloudpaks/cp4i/resources/templates/05-crds/api-connect.yaml
@@ -1,4 +1,5 @@
 ---
+# https://ibm.biz/integration-documentation
 apiVersion: apiconnect.ibm.com/v1beta1
 kind: APIConnectCluster
 metadata:
@@ -14,7 +15,7 @@ spec:
   license:
     accept: true
     use: nonproduction
-    license: L-RJON-C2YLGB
+    license: {{.Values.api_connect.license}}
   storageClassName: {{.Values.storageclass.rwo}}
   profile: n1xc10.m48
-  version: 10.0.3.0
+  version: {{.Values.api_connect.version}}

--- a/config/cloudpaks/cp4i/resources/templates/05-crds/platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/resources/templates/05-crds/platform-navigator.yaml
@@ -1,4 +1,5 @@
 ---
+# https://ibm.biz/integration-documentation
 apiVersion: integration.ibm.com/v1beta1
 kind: PlatformNavigator
 metadata:
@@ -9,9 +10,9 @@ metadata:
 spec:
   license:
     accept: true
-    license: L-RJON-BZFQU2
+    license: {{.Values.platform_navigator.license}}
   mqDashboard: true
-  version: 2021.2.1
+  version: {{.Values.platform_navigator.version}}
   replicas: 1
   storage:
     class: {{.Values.storageclass.rwx}}

--- a/config/cloudpaks/cp4i/resources/templates/05-crds/queue-manager.yaml
+++ b/config/cloudpaks/cp4i/resources/templates/05-crds/queue-manager.yaml
@@ -7,10 +7,10 @@ metadata:
   name: case-queues-1-qmgr
   namespace: {{.Values.argocd_app_namespace}}
 spec:
-  version: 9.2.2.0-r1
+  version: {{.Values.queue_manager.version}}
   license:
     accept: true
-    license: L-RJON-BXUPZ2
+    license: {{.Values.queue_manager.license}}
     use: NonProduction
   web:
     enabled: true

--- a/config/cloudpaks/cp4i/resources/values.yaml
+++ b/config/cloudpaks/cp4i/resources/values.yaml
@@ -4,5 +4,14 @@ serviceaccount:
 metadata:
   argocd_namespace: openshift-gitops
 storageclass:
-  rwo: ibmc-file-gold-gid
+  rwo: ibmc-block-gold
   rwx: ibmc-file-gold-gid
+api_connect:
+  license: L-RJON-C2YLGB
+  version: 10.0.3
+platform_navigator:
+  license: L-RJON-C5CSNH
+  version: 2021.3.1
+queue_manager:
+  license: L-RJON-BZFQU2
+  version: 9.2.3.0-r1


### PR DESCRIPTION
Closes: #53

Description of changes:
- Updates to channels, versions and license codes.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-ga                                   53-cp4i-upgrade
cicd-app                https://kubernetes.default.svc  cicd              default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp-shared                  53-cp4i-upgrade
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp-shared/operators               53-cp4i-upgrade
cp4i-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp4i                       53-cp4i-upgrade
cp4i-client             https://kubernetes.default.svc  dev               default  OutOfSync  Missing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              
cp4i-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4i/operators                    53-cp4i-upgrade
cp4i-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy  <none>      <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4i/resources                    53-cp4i-upgrade
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  
dev-env                 https://kubernetes.default.svc  dev               default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/sbo                                         
stage-env               https://kubernetes.default.svc  stage             default  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    
```
