### PR TITLE
fix: Comply to stable API for SBO

### DIFF
--- a/config/cloudpaks/cp4i/client/base/kustomization.yaml
+++ b/config/cloudpaks/cp4i/client/base/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - mq-dev-patterns-node-deployment.yaml
   - openjdk-imagestream.yaml
   - node-imagestream.yaml
+  - sbo-account-role-binding.yaml
   - service-binding.yaml

--- a/config/cloudpaks/cp4i/client/base/mq-dev-patterns-jms-deployment.yaml
+++ b/config/cloudpaks/cp4i/client/base/mq-dev-patterns-jms-deployment.yaml
@@ -25,7 +25,10 @@ spec:
         app.kubernetes.io/part-of: app-mq-dev-patterns
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/dev/mq-dev-patterns-jms:latest
+        - env:
+            - name: SERVICE_BINDING_ROOT
+              value: /config
+          image: image-registry.openshift-image-registry.svc:5000/dev/mq-dev-patterns-jms:latest
           imagePullPolicy: Always
           name: mq-dev-patterns-jms
           ports:

--- a/config/cloudpaks/cp4i/client/base/mq-dev-patterns-node-deployment.yaml
+++ b/config/cloudpaks/cp4i/client/base/mq-dev-patterns-node-deployment.yaml
@@ -25,7 +25,10 @@ spec:
         app.kubernetes.io/part-of: app-mq-dev-patterns
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/dev/mq-dev-patterns-node:latest
+        - env:
+            - name: SERVICE_BINDING_ROOT
+              value: /config
+          image: image-registry.openshift-image-registry.svc:5000/dev/mq-dev-patterns-node:latest
           imagePullPolicy: Always
           name: mq-dev-patterns-node
           ports:

--- a/config/cloudpaks/cp4i/client/base/sbo-account-role-binding.yaml
+++ b/config/cloudpaks/cp4i/client/base/sbo-account-role-binding.yaml
@@ -1,0 +1,18 @@
+---
+# https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48099
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: sbo-admin-cloudpaks
+  namespace: ibm-cloudpaks
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - kind: ServiceAccount
+    name: service-binding-operator
+    namespace: openshift-operators

--- a/config/cloudpaks/cp4i/client/base/service-binding.yaml
+++ b/config/cloudpaks/cp4i/client/base/service-binding.yaml
@@ -16,7 +16,6 @@ spec:
     version: v1
     resource: deployments
   bindAsFiles: true
-  mountPath: /config
   services:
     - group: mq.ibm.com
       version: v1beta1


### PR DESCRIPTION
Closes: #55

Description of changes:
- Minor tweak to resource definition for ServiceBinding resource
- Minor tweaks to pod deployments using the build images (also require a minor change to the source code of the application)


Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-ga                                   55-fix-cp4i-client
cicd-app                https://kubernetes.default.svc  cicd              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp-shared                  55-fix-cp4i-client
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp-shared/operators               55-fix-cp4i-client
cp4i-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp4i                       55-fix-cp4i-client
cp4i-client             https://kubernetes.default.svc  dev               default  Synced  Healthy  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              55-fix-cp4i-client
cp4i-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4i/operators                    55-fix-cp4i-client
cp4i-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  <none>      <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4i/resources                    55-fix-cp4i-client
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  
dev-env                 https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/sbo                                         
stage-env               https://kubernetes.default.svc  stage             default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays         
```
