### PR TITLE
fix: Add missing cluster roles and secrets

### DIFF
--- a/config/cicd/base/02-rolebindings/pipeline-service-role.yaml
+++ b/config/cicd/base/02-rolebindings/pipeline-service-role.yaml
@@ -34,3 +34,11 @@ rules:
       - get
       - create
       - patch
+  - apiGroups:
+      - triggers.tekton.dev
+    resources:
+      - clusterinterceptors
+    verbs:
+      - get
+      - watch
+      - list

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,6 +85,22 @@ Updating the OCP global pull secret triggers the staggered restart of each node 
 You can perform the reloading or replacement of workers directly from the cluster page in the IBM Cloud console or use a terminal, following the instructions listed [here](https://cloud.ibm.com/docs/openshift?topic=openshift-registry&_ga=2.262606922.775805413.1629911830-822975074.1629149367#cluster_global_pull_secret).
 
 
+## Update the pull secret in the openshift-gitops namespace
+
+Global pull secrets require granting too much priviledge to the OpenShift GitOps service account, so we have started to transition to the definition of pull secrets at a namespace level.
+
+The Application resources are transitioning to use `PreSync` hooks to copy the entitlement key from a `Secret` named `ibm-entitlement-key` in the `openshift-gitops` namespace, so issue the following command to create that secret:
+
+```
+ oc create secret docker-registry ibm-entitlement-key \
+        --docker-server=cp.icr.io \
+        --docker-username=cp \
+        --docker-password="${IBM_ENTITLEMENT_KEY:?}" \
+        --docker-email="non-existent-replace-with0-yours@email.com" \
+        --namespace=openshift-gitops
+```
+
+
 ## Adding Cloud Pak GitOps Application objects to your GitOps server
 
 The instructions in this section assume you have administrative privileges to the cluster.


### PR DESCRIPTION
Contributes to: #45

Description of changes:
- Tekton Pipelines need another cluster role
- Add missing pull secret to instructions

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

