### PR TITLE
fix: Auto-detection of EFS on AWS

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/templates/00-presync-common-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/00-presync-common-config-map.yaml
@@ -45,8 +45,8 @@ spec:
               else
                   platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
                   if [ "${platform}" == "AWS" ]; then
-                      ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1)
-                      efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1)
+                      ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
+                      efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
                       if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
                           storage_class_rwo="${ebs}"
                           storage_class_rwx="${efs}"

--- a/config/argocd-cloudpaks/cp-shared/templates/00-presync-cp4a-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/00-presync-cp4a-config-map.yaml
@@ -48,7 +48,7 @@ spec:
                  storage_class="{{.Values.storageclass.rwx.fyre}}"
               else
                 if [ "${platform}" == "AWS" ]; then
-                  efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1)
+                  efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
                   if [ -m "${efs}" ]; then
                     storage_class="${efs}"
                   else


### PR DESCRIPTION
Closes: #58

Description of changes:
- Pod was exiting with error on AWS when not using EFS storage

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                                   58-aws-efs
cicd-app                https://kubernetes.default.svc  cicd              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            HEAD
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared                  58-aws-efs
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators               HEAD
cp4aiops-app            https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops                   58-aws-efs
cp4aiops-operators      https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators                HEAD
cp4aiops-resources      https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources                HEAD
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  HEAD
dev-env                 https://kubernetes.default.svc  dev               default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      HEAD
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/sbo                                         HEAD
stage-env               https://kubernetes.default.svc  stage             default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    HEAD
```