### PR TITLE
fix: Create namespaces conditionally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Making changes to this repository requires a working knowledge of Argo CD admini
         --repo <url-fork-or-clone> \
         --revision <branch-in-repo> \
         --helm-set repoURL=<url-fork-or-clone> \
-        --helm-set targetRevisiton=<branch-in-repo>
+        --helm-set targetRevision=<branch-in-repo>
     ```
 
     For instance, assuming you cloned this repo into https://github.com/nastacio/cloudpak-gitops, and you wanted to make changes to the `cp4i-app` Application in a branch named `new-feature`, you would run the command like this:
@@ -31,7 +31,7 @@ Making changes to this repository requires a working knowledge of Argo CD admini
         --repo https://github.com/nastacio/cloudpak-gitops \
         --revision new-feature \
         --helm-set repoURL=https://github.com/nastacio/cloudpak-gitops \
-        --helm-set targetRevisiton=new-feature
+        --helm-set targetRevision=new-feature
     ```
 
     Since the application has an automated synchronization policy, the synchronization with the new repository and branch would start immediately.

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
@@ -32,8 +32,6 @@ spec:
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller
           value: {{.Values.serviceaccount.argocd_application_controller}}
-        - name: spec.shared_configuration.sc_deployment_hostname_suffix
-          value: {{.Values.spec.shared_configuration.sc_deployment_hostname_suffix}}
         - name: spec.shared_configuration.sc_deployment_platform
           value: {{.Values.spec.shared_configuration.sc_deployment_platform}}
         - name: storageclass.bronze

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-operator-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-operator-app.yaml
@@ -26,6 +26,8 @@ spec:
           value: ${ARGOCD_APP_NAME}
         - name: argocd_app_namespace
           value: ${ARGOCD_APP_NAMESPACE}
+        - name: metadata.argocd_app_namespace
+          value: {{.Values.metadata.argocd_app_namespace}}
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-resources-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-resources-app.yaml
@@ -18,10 +18,6 @@ spec:
         - /spec/source/targetRevision
         - /status
       kind: Application
-    - group: icp4a.ibm.com
-      jsonPointers:
-        - /spec.shared_configuration.sc_deployment_hostname_suffix
-      kind: ICP4ACluster
   project: default
   source:
     helm:
@@ -36,8 +32,6 @@ spec:
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller
           value: {{.Values.serviceaccount.argocd_application_controller}}
-        - name: spec.shared_configuration.sc_deployment_hostname_suffix
-          value: {{.Values.spec.shared_configuration.sc_deployment_hostname_suffix}}
         - name: spec.shared_configuration.sc_deployment_platform
           value: {{.Values.spec.shared_configuration.sc_deployment_platform}}
         - name: storageclass.bronze

--- a/config/cloudpaks/cp4a/operators/Chart.yaml
+++ b/config/cloudpaks/cp4a/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4a/operators/templates/01-namespaces/individual.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/01-namespaces/individual.yaml
@@ -1,8 +1,10 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
-  name: {{.Values.metadata.individual_namespace}}
+  name: {{.Values.metadata.argocd_app_namespace}}
 spec: {}
 status: {}
+{{ end }}

--- a/config/cloudpaks/cp4a/operators/templates/07-operators/operator-group.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/07-operators/operator-group.yaml
@@ -1,11 +1,13 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: "{{.Values.metadata.individual_namespace}}-operator-group"
-  namespace: "{{.Values.metadata.individual_namespace}}"
+  name: "{{.Values.metadata.argocd_app_namespace}}-operator-group"
+  namespace: "{{.Values.metadata.argocd_app_namespace}}"
   annotations:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   targetNamespaces:
-    - {{.Values.metadata.individual_namespace}}
+    - {{.Values.metadata.argocd_app_namespace}}
+{{ end }}

--- a/config/cloudpaks/cp4a/operators/values.yaml
+++ b/config/cloudpaks/cp4a/operators/values.yaml
@@ -1,6 +1,6 @@
 ---
 metadata:
-  individual_namespace: cp4a
+  argocd_app_namespace: ibm-cloudpaks
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller
 storageclass:

--- a/config/cloudpaks/cp4aiops/operators/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/00-namespaces.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/00-namespaces.yaml
@@ -1,8 +1,10 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
-  name: {{.Values.metadata.individual_namespace}}
+  name: {{.Values.metadata.argocd_app_namespace}}
 spec: {}
 status: {}
+{{ end }}

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
@@ -1,12 +1,13 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
+  name: "{{.Values.metadata.argocd_app_namespace}}-operator-group"
+  namespace: "{{.Values.metadata.argocd_app_namespace}}"
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
-  creationTimestamp: null
-  name: "{{.Values.metadata.individual_namespace}}-operator-group"
-  namespace: "{{.Values.metadata.individual_namespace}}"
+    argocd.argoproj.io/sync-wave: "100"
 spec:
   targetNamespaces:
-    - {{.Values.metadata.individual_namespace}}
+    - {{.Values.metadata.argocd_app_namespace}}
+{{ end }}

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
@@ -1,3 +1,4 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -7,3 +8,4 @@ metadata:
   name: "{{.Values.metadata.argocd_app_namespace}}-evt"
 spec: {}
 status: {}
+{{ end }}

--- a/config/cloudpaks/cp4aiops/operators/values.yaml
+++ b/config/cloudpaks/cp4aiops/operators/values.yaml
@@ -1,6 +1,5 @@
 ---
 metadata:
   argocd_app_namespace: ibm-cloudpaks
-  individual_namespace: cp4aiops
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller

--- a/config/cloudpaks/cp4i/operators/Chart.yaml
+++ b/config/cloudpaks/cp4i/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4i/operators/templates/01-namespaces/individual.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/01-namespaces/individual.yaml
@@ -1,8 +1,10 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
-  name: {{.Values.metadata.individual_namespace}}
+  name: {{.Values.metadata.argocd_app_namespace}}
 spec: {}
 status: {}
+{{ end }}

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/operator-group.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/operator-group.yaml
@@ -1,11 +1,13 @@
+{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: "{{.Values.metadata.individual_namespace}}-operator-group"
-  namespace: "{{.Values.metadata.individual_namespace}}"
+  name: "{{.Values.metadata.argocd_app_namespace}}-operator-group"
+  namespace: "{{.Values.metadata.argocd_app_namespace}}"
   annotations:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   targetNamespaces:
-    - {{.Values.metadata.individual_namespace}}
+    - {{.Values.metadata.argocd_app_namespace}}
+{{ end }}

--- a/config/cloudpaks/cp4i/operators/values.yaml
+++ b/config/cloudpaks/cp4i/operators/values.yaml
@@ -1,6 +1,6 @@
 ---
 metadata:
   argocd_namespace: openshift-gitops
-  individual_namespace: cp4i
+  argocd_app_namespace: ibm-cloudpaks
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller

--- a/config/rhacm/cloudpaks/Chart.yaml
+++ b/config/rhacm/cloudpaks/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
@@ -54,8 +54,6 @@ spec:
                           value: ${ARGOCD_APP_SOURCE_REPO_URL}
                         - name: serviceaccount.argocd_application_controller
                           value: '{{ "{{ fromConfigMap \"openshift-gitops\" \"argocd-cp4a-config\" \"serviceaccount.argocd_application_controller\" }}" }}'
-                        - name: spec.shared_configuration.sc_deployment_hostname_suffix
-                          value: '{{ "{{ fromConfigMap \"openshift-gitops\" \"argocd-cp4a-config\" \"shared_configuration.sc_deployment_hostname_suffix\" }}" }}'
                         - name: spec.shared_configuration.sc_deployment_platform
                           value: '{{ "{{ fromConfigMap \"openshift-gitops\" \"argocd-cp4a-config\" \"shared_configuration.sc_deployment_platform\" }}" }}'
                         - name: storageclass.bronze

--- a/docs/install.md
+++ b/docs/install.md
@@ -320,14 +320,20 @@ After completing the list of activities listed in the previous sections, you hav
    # config/argocd-cloudpaks/cp4i/cp4a, config/argocd-cloudpaks/cp4i, 
    # etc
    app_path=config/argocd-cloudpaks/${cp}
+   cp_namespace=ibm-cloudpaks
+   gitops_branch=main
 
    argocd app create "${app_name}" \
          --project default \
          --dest-namespace openshift-gitops \
          --dest-server https://kubernetes.default.svc \
-         --repo https://github.com/IBM/cloudpak-gitops \
-         --path "${app_path}" \
+         --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
+         --helm-set-string repoURL=https://github.com/IBM/cloudpak-gitops \
          --helm-set-string serviceaccount.argocd_application_controller=${sa_account} \
+         --helm-set-string targetRevision="${gitops_branch}" \
+         --path "${app_path}" \
+         --repo https://github.com/IBM/cloudpak-gitops \
+         --revision "${gitops_branch}" \
          --sync-policy automated \
          --upsert 
    argocd app wait "${app_name}"

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -1,9 +1,16 @@
 ---
 ignore: |
+  config/cloudpaks/cp4a/operators/templates/01-namespaces/individual.yaml
+  config/cloudpaks/cp4a/operators/templates/07-operators/operator-group.yaml
+  config/cloudpaks/cp4aiops/operators/templates/ai-manager/00-namespaces.yaml
+  config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
+  config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
+  config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
+  config/cloudpaks/cp4i/operators/templates/01-namespaces/individual.yaml
+  config/cloudpaks/cp4i/operators/templates/04-operators/operator-group.yaml
   config/rhacm/cloudpaks/templates/placement-argocd.yaml
   config/rhacm/cloudpaks/templates/placement-cloudpaks.yaml
   config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
-  config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
 
 rules:
   yaml-files:


### PR DESCRIPTION
Contributes to: #66

Description of changes:
- Only create individual Cloud Pak namespaces if different than `ibm-cloudpaks`

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS     HEALTH       SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                                   66-fix-ns
cicd-app                https://kubernetes.default.svc  cicd              default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            66-fix-ns
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared                  66-fix-ns
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators               66-fix-ns
cp4a-app                https://kubernetes.default.svc  mycp4a            default  OutOfSync  Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a                       66-fix-ns
cp4a-operators          https://kubernetes.default.svc  mycp4a            default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators                    66-fix-ns
cp4a-resources          https://kubernetes.default.svc  mycp4a            default  Synced     Progressing  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources                    66-fix-ns
cp4aiops-app            https://kubernetes.default.svc  mycp4aiops        default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops                   66-fix-ns
cp4aiops-operators      https://kubernetes.default.svc  mycp4aiops        default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators                66-fix-ns
cp4aiops-resources      https://kubernetes.default.svc  mycp4aiops        default  Synced     Progressing  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources                66-fix-ns
cp4i-app                https://kubernetes.default.svc  mycloudpak        default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i                       66-fix-ns
cp4i-client             https://kubernetes.default.svc  dev               default  Synced     Progressing  <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              66-fix-ns
cp4i-operators          https://kubernetes.default.svc  mycloudpak        default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/operators                    66-fix-ns
cp4i-resources          https://kubernetes.default.svc  mycloudpak        default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/resources                    66-fix-ns
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  66-fix-ns
dev-env                 https://kubernetes.default.svc  dev               default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      66-fix-ns
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/sbo                                         66-fix-ns
stage-env               https://kubernetes.default.svc  stage             default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    66-fix-ns

```