### PR TITLE
fix: Ignore NOI clusterDomain field

### DIFF
--- a/config/argocd-cloudpaks/cp4aiops/templates/cp4aiops-resources-app.yaml
+++ b/config/argocd-cloudpaks/cp4aiops/templates/cp4aiops-resources-app.yaml
@@ -18,6 +18,10 @@ spec:
         - /spec/source/targetRevision
         - /status
       kind: Application
+    - group: noi.ibm.com
+      jsonPointers:
+        - /spec/clusterDomain
+      kind: NOI
   project: default
   source:
     helm:


### PR DESCRIPTION
Contributes to: #58 

Description of changes:
- Avoid repeat loop due to clusterDomain field in Cloud Pak for AIOps

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS   HEALTH       SYNCPOLICY  CONDITIONS       REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                                   66-ignore-aiops-noi
cicd-app                https://kubernetes.default.svc  cicd              default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            66-ignore-aiops-noi
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared                  66-ignore-aiops-noi
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators               66-ignore-aiops-noi
cp4a-app                https://kubernetes.default.svc  mycp4a            default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a                       66-ignore-aiops-noi
cp4a-operators          https://kubernetes.default.svc  mycp4a            default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators                    66-ignore-aiops-noi
cp4a-resources          https://kubernetes.default.svc  mycp4a            default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources                    66-ignore-aiops-noi
cp4aiops-app            https://kubernetes.default.svc  mycp4aiops        default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops                   66-ignore-aiops-noi
cp4aiops-operators      https://kubernetes.default.svc  mycp4aiops        default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators                66-ignore-aiops-noi
cp4aiops-resources      https://kubernetes.default.svc  mycp4aiops        default  Synced   Progressing  Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources                66-ignore-aiops-noi
cp4i-app                https://kubernetes.default.svc  mycloudpak        default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i                       66-ignore-aiops-noi
cp4i-client             https://kubernetes.default.svc  dev               default  Synced   Progressing  <none>      <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              66-ignore-aiops-noi
cp4i-operators          https://kubernetes.default.svc  mycloudpak        default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/operators                    66-ignore-aiops-noi
cp4i-resources          https://kubernetes.default.svc  mycloudpak        default  Synced   Healthy      Auto-Prune  <none>           https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/resources                    66-ignore-aiops-noi
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Unknown  Healthy      Auto-Prune  ComparisonError  https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  66-fix-ns
dev-env                 https://kubernetes.default.svc  dev               default  Unknown  Healthy      Auto-Prune  ComparisonError  https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      66-fix-ns
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Unknown  Healthy      Auto-Prune  ComparisonError  https://github.com/IBM/cloudpak-gitops.git  config/sbo                                         66-fix-ns
stage-env               https://kubernetes.default.svc  stage             default  Unknown  Healthy      Auto-Prune  ComparisonError  https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    66-fix-ns
```