### PR TITLE
fix: Event manager namespace is not conditional

### DIFF
--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
@@ -1,4 +1,3 @@
-{{ if not ( eq ( default "" .Values.metadata.argocd_app_namespace ) "ibm-cloudpaks" ) }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -8,4 +7,3 @@ metadata:
   name: "{{.Values.metadata.argocd_app_namespace}}-evt"
 spec: {}
 status: {}
-{{ end }}

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: orchestrator.aiops.ibm.com/v1alpha1
 kind: Installation
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "210"
   name: ibm-cp-watson-aiops
   namespace: "{{.Values.metadata.argocd_app_namespace}}"

--- a/config/cloudpaks/cp4aiops/resources/templates/evt-manager/05-event-manager.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/evt-manager/05-event-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: noi.ibm.com/v1beta1
 kind: NOI
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "210"
   creationTimestamp: null
   name: evtmanager

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -5,7 +5,6 @@ ignore: |
   config/cloudpaks/cp4aiops/operators/templates/ai-manager/00-namespaces.yaml
   config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
   config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
-  config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
   config/cloudpaks/cp4i/operators/templates/01-namespaces/individual.yaml
   config/cloudpaks/cp4i/operators/templates/04-operators/operator-group.yaml
   config/rhacm/cloudpaks/templates/placement-argocd.yaml


### PR DESCRIPTION
Contributes to: #58

Description of changes:
- Make the namespace for event manager managed in the cp4aiops app

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
# argocd app list -l  app.kubernetes.io/instance=cp4aiops-app
NAME                CLUSTER                         NAMESPACE      PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                 TARGET
cp4aiops-app        https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops     58-fix-evt-mgr
cp4aiops-operators  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators  58-fix-evt-mgr
cp4aiops-resources  https://kubernetes.default.svc  ibm-cloudpaks  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources  58-fix-evt-mgr
```