### PR TITLE
fix: Patch AIManager with IAF

### DIFF
--- a/config/cloudpaks/cp4aiops/resources/templates/00-presync-adjust-parameters.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/00-presync-adjust-parameters.yaml
@@ -24,7 +24,7 @@ spec:
             - name: ARGOCD_NAMESPACE
               value: "openshift-gitops"
             - name: TARGET_NAMESPACE
-              value: "{{.Values.metadata.argocd_app_namespace}}-evt"
+              value: {{.Values.metadata.argocd_app_namespace}}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Contributes to: #58

Description of changes:
- Patch AI Manager with IAF was using the Event Manager namespace and failing

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                    CLUSTER                         NAMESPACE         PROJECT  STATUS     HEALTH    SYNCPOLICY  CONDITIONS  REPO                                        PATH                                               TARGET
argo-app                https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                                   58-fix-aiops
cicd-app                https://kubernetes.default.svc  cicd              default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cicd/overlays-ga                            HEAD
cp-shared-app           https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared                  58-fix-aiops
cp-shared-operators     https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators               HEAD
cp4a-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a                       58-fix-aiops
cp4a-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators                    HEAD
cp4a-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Degraded  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources                    HEAD
cp4aiops-app            https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops                   58-fix-aiops
cp4aiops-operators      https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators                58-fix-aiops
cp4aiops-resources      https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources                58-fix-aiops
cp4i-app                https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i                       58-fix-aiops
cp4i-client             https://kubernetes.default.svc  dev               default  OutOfSync  Missing   <none>      <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/client/overlays              HEAD
cp4i-operators          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/operators                    HEAD
cp4i-resources          https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/resources                    HEAD
dev-app-gitops-service  https://kubernetes.default.svc  dev               default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/apps/app-gitops-service/overlays  HEAD
dev-env                 https://kubernetes.default.svc  dev               default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/dev/env/overlays                      HEAD
sbo-operators           https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/sbo                                         HEAD
stage-env               https://kubernetes.default.svc  stage             default  Synced     Healthy   Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  environments/stage/env/overlays                    HEAD
```
