### PR TITLE
bug: Missing "cp4d" placement rules

### DIFF
--- a/config/rhacm/cloudpaks/templates/placement-argocd.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-argocd.yaml
@@ -1,4 +1,4 @@
-{{- range tuple "cp4a" "cp4aiops" "cp4i" }}
+{{- range tuple "cp4a" "cp4aiops" "cp4d" "cp4i" }}
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
@@ -1,4 +1,4 @@
-{{- range tuple "cp4a" "cp4aiops" "cp4i" }}
+{{- range tuple "cp4a" "cp4aiops" "cp4d" "cp4i" }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
Contributes to: #73

Description of changes:
- Missing placement rule for GitOps matching `cp4d` deployments

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

