### PR TITLE
bug: Create common-services operator group

### DIFF
--- a/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
+++ b/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
@@ -13,13 +13,6 @@ spec:
         - name: config
           image: quay.io/openshift/origin-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "128Mi"
-              cpu: "150m"
-            limits:
-              memory: "128Mi"
-              cpu: "200m"
           command:
             - /bin/sh
             - -c
@@ -44,7 +37,7 @@ spec:
               apiVersion: operators.coreos.com/v1
               kind: OperatorGroup
               metadata:
-                name: "${cs_namespace}"-operators
+                name: "${cs_namespace}-operators"
                 namespace: "${cs_namespace}"
               spec:
                 targetNamespaces:

--- a/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
+++ b/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
@@ -15,10 +15,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "64Mi"
+              memory: "96Mi"
               cpu: "150m"
             limits:
-              memory: "64Mi"
+              memory: "96Mi"
               cpu: "200m"
           command:
             - /bin/sh

--- a/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
+++ b/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
@@ -30,8 +30,8 @@ spec:
               og_not_found=0
 
               cs_namespace=ibm-common-services
-
-              if oc get OperatorGroup -n "${cs_namespace}" 2> /dev/null ; then
+              operator_group_present=$(oc get OperatorGroup -n "${cs_namespace}" | wc -l)
+              if [ ${operator_group_present} -gt 0 ]; then
                 echo "INFO: Operator group for namespace "${cs_namespace}" already created."
                 exit 0
               else

--- a/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
+++ b/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
@@ -40,7 +40,7 @@ spec:
 
               # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=tasks-setting-up-projects-namespaces
               # This operator group may or may not be created by another Cloud Pak, so ensuring its creation here.
-              cat << EOF > oc apply -f -
+              cat << EOF | oc apply -f -
               apiVersion: operators.coreos.com/v1
               kind: OperatorGroup
               metadata:

--- a/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
+++ b/config/cloudpaks/cp4d/install-platform/templates/prereqs/020-operator-group-cs.yaml
@@ -15,10 +15,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "96Mi"
+              memory: "128Mi"
               cpu: "150m"
             limits:
-              memory: "96Mi"
+              memory: "128Mi"
               cpu: "200m"
           command:
             - /bin/sh


### PR DESCRIPTION
Contributes to: #73 

Description of changes:
- The new logic stopped creating OperatorGroup regardless of its presence. Fixed it.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

