### PR TITLE
feat: Default to ODF storage classes

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/templates/00-presync-common-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/00-presync-common-config-map.yaml
@@ -37,42 +37,46 @@ spec:
                   exit 1
               fi
 
-              storage_class_rwo=""
-              storage_class_rwx=""
-              if [[ "${api_url}" == *fyre.ibm.com* ]]; then
-                 storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
-                 storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
+              storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
+              storage_class_rwx=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
+              if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                  echo "INFO: Cluster has ODF installed, using ODF storage classes."
               else
-                  platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
-                  if [ "${platform}" == "AWS" ]; then
-                      ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
-                      efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
-                      if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
-                          storage_class_rwo="${ebs}"
-                          storage_class_rwx="${efs}"
+                if [[ "${api_url}" == *fyre.ibm.com* ]]; then
+                  storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
+                  storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
+                else
+                    platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
+                    if [ "${platform}" == "AWS" ]; then
+                        ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
+                        efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
+                        if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
+                            storage_class_rwo="${ebs}"
+                            storage_class_rwx="${efs}"
+                        else
+                            storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
+                            storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
+                        fi
+                    elif [ "${platform}" == "Azure" ]; then
+                        if oc get StorageClass azure-file 2> /dev/null &&
+                          oc get StorageClass managed-premium 2> /dev/null; then
+                            storage_class_rwo=managed-premium
+                            storage_class_rwx=azure-file
+                        else
+                            storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
+                            storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
+                        fi
+                    elif [ "${platform}" == "IBMCloud" ]; then
+                      vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
+                      if [ ${vpc_class} -gt 0 ]; then
+                          storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
+                          storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
                       else
-                          storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
+                          storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
+                          storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
                       fi
-                  elif [ "${platform}" == "Azure" ]; then
-                      if oc get StorageClass azure-file 2> /dev/null &&
-                         oc get StorageClass managed-premium 2> /dev/null; then
-                          storage_class_rwo=managed-premium
-                          storage_class_rwx=azure-file
-                      else
-                          storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
-                      fi
-                  elif [ "${platform}" == "IBMCloud" ]; then
-                    vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
-                    if [ ${vpc_class} -gt 0 ]; then
-                        storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
-                        storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
-                    else
-                        storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
-                        storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
                     fi
-                  fi
+                fi
               fi
 
               if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then

--- a/config/argocd-cloudpaks/cp-shared/templates/00-presync-cp4a-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/00-presync-cp4a-config-map.yaml
@@ -43,29 +43,33 @@ spec:
 
               api_url=$(oc get Infrastructure cluster  -o jsonpath={.status.apiServerURL})
 
-              storage_class=""
-              if [[ "${api_url}" == *fyre.ibm.com* ]]; then
-                 storage_class="{{.Values.storageclass.rwx.fyre}}"
+              storage_class=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
+              if [ -n "${storage_class}" ]; then
+                  echo "INFO: Cluster has ODF installed, using ODF storage classes."
               else
-                if [ "${platform}" == "AWS" ]; then
-                  efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
-                  if [ -n "${efs}" ]; then
-                    storage_class="${efs}"
-                  else
-                    storage_class="{{.Values.storageclass.rwx.aws}}"
-                  fi
-                elif [ "${platform}" == "Azure" ]; then
-                  if oc get StorageClass azure-file; then
-                    storage_class=azure-file
-                  else
-                    storage_class="{{.Values.storageclass.rwx.azure}}"
-                  fi
-                elif [ "${platform}" == "IBMCloud" ]; then
-                  vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
-                  if [ ${vpc_class} -gt 0 ]; then
-                      storage_class="{{.Values.storageclass.rwx.roksgen2}}"
-                  else
-                      storage_class_rwo="{{.Values.storageclass.rwx.roks}}"
+                if [[ "${api_url}" == *fyre.ibm.com* ]]; then
+                  storage_class="{{.Values.storageclass.rwx.fyre}}"
+                else
+                  if [ "${platform}" == "AWS" ]; then
+                    efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
+                    if [ -n "${efs}" ]; then
+                      storage_class="${efs}"
+                    else
+                      storage_class="{{.Values.storageclass.rwx.aws}}"
+                    fi
+                  elif [ "${platform}" == "Azure" ]; then
+                    if oc get StorageClass azure-file; then
+                      storage_class=azure-file
+                    else
+                      storage_class="{{.Values.storageclass.rwx.azure}}"
+                    fi
+                  elif [ "${platform}" == "IBMCloud" ]; then
+                    vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
+                    if [ ${vpc_class} -gt 0 ]; then
+                        storage_class="{{.Values.storageclass.rwx.roksgen2}}"
+                    else
+                        storage_class="{{.Values.storageclass.rwx.roks}}"
+                    fi
                   fi
                 fi
               fi


### PR DESCRIPTION
Contributes to: #88

Description of changes:
- Detect ODF storage classes before starting considering the target cloud.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT  STATUS     HEALTH       SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                      88-favor-odf-sc
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared     88-favor-odf-sc
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators  88-favor-odf-sc
cp4a-app             https://kubernetes.default.svc  cp4a              default  OutOfSync  Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a          88-favor-odf-sc
cp4aiops-app         https://kubernetes.default.svc  cp4aiops          default  Synced     Progressing  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops      88-favor-odf-sc
cp4aiops-operators   https://kubernetes.default.svc  cp4aiops          default  Synced     Healthy      Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators   88-favor-odf-sc
cp4aiops-resources   https://kubernetes.default.svc  cp4aiops          default  Synced     Progressing  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources   88-favor-odf-sc
```

Evidence of `cp-shared` app populating the respective `ConfigMap` objects correctly when the repository is applied against a ROKS cluster containing ODF (the previous version of the code would populate the storage class fields with ROKS storage classes) :

```
 oc describe ConfigMap argocd-cp4a-config -n openshift-gitops
Name:         argocd-cp4a-config
Namespace:    openshift-gitops
Labels:       <none>
Annotations:  <none>

Data
====
storageclass.gold:
----
ocs-storagecluster-cephfs
storageclass.silver:
----
ocs-storagecluster-cephfs
serviceaccount.argocd_application_controller:
----
openshift-gitops-argocd-application-controller
shared_configuration.sc_deployment_platform:
----
ROKS
storageclass.bronze:
----
ocs-storagecluster-cephfs
```

```
oc describe ConfigMap argocd-cp4aiops-config -n openshift-gitops
Name:         argocd-cp4aiops-config
Namespace:    openshift-gitops
Labels:       <none>
Annotations:  <none>

Data
====
cluster_domain:
----
pd-cp4aiops-1e3af63cfd19e855098d645120e18baf-0000.upi.containers.appdomain.cloud
serviceaccount.argocd_application_controller:
----
openshift-gitops-argocd-application-controller
storageclass.rwo:
----
ocs-storagecluster-ceph-rbd
storageclass.rwx:
----
ocs-storagecluster-cephfs
```