### PR TITLE
 chore: OLM installation for CP4AIOps Event Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Refer to the [RHACM page](docs/rhacm.md) for an overview and instructions on how
 
 Making changes to this repository requires a working knowledge of Argo CD administration and configuration. This section describes the workflow of submitting a change. A change entails forking the repository, modifying it, installing the changes on a target cluster to validate them, then gathering the output of validation commands using the `argocd` command-line interface.
 
-Navigate to the [contributing](CONTRIBUTING.md) page for details on validating changes and submitting a pull request will all the required information.
+Navigate to the [contributing](CONTRIBUTING.md) page for details on validating changes and submitting a pull request with all the required information.

--- a/config/cloudpaks/cp4aiops/operators/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/operators/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "3.2.0"

--- a/config/cloudpaks/cp4aiops/operators/templates/01-argocd-admin-namespace.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/01-argocd-admin-namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
   creationTimestamp: null
-  name: openshift-gitops-admin-emgr
+  name: openshift-gitops-admin
   namespace: "{{.Values.metadata.argocd_app_namespace}}-emgr"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/01-argocd-admin-namespace.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/01-argocd-admin-namespace.yaml
@@ -5,8 +5,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
   creationTimestamp: null
-  name: openshift-gitops-admin-emgr
-  namespace: "{{.Values.metadata.argocd_app_namespace}}-emgr"
+  name: openshift-gitops-admin-aimgr
+  namespace: "{{.Values.metadata.argocd_app_namespace}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/05-operator-group.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{.Values.metadata.argocd_app_namespace}}-operator-group"
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
+    argocd.argoproj.io/sync-wave: "50"
 spec:
   targetNamespaces:
     - {{.Values.metadata.argocd_app_namespace}}

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/99-sync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/99-sync-check-all-csvs.yaml
@@ -3,9 +3,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: post-check-aiops-ai-csvs
+  name: check-aiops-ai-csvs
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: "110"
+    argocd.argoproj.io/hook: Sync
   namespace: openshift-gitops
 spec:
   template:

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/00-namespaces.yaml
@@ -4,6 +4,6 @@ kind: Namespace
 metadata:
   creationTimestamp: null
   labels: {}
-  name: "{{.Values.metadata.argocd_app_namespace}}-evt"
+  name: "{{.Values.metadata.argocd_app_namespace}}-emgr"
 spec: {}
 status: {}

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/02-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/02-sync-prereqs.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-install-evt-mgr-operator
+  name: sync-emgr-prereqs
   annotations:
+    argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/sync-wave: "100"
   namespace: openshift-gitops
 spec:
   template:
@@ -16,18 +16,18 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "512Mi"
-              cpu: "300m"
+              memory: "64Mi"
+              cpu: "200m"
             limits:
-              memory: "512Mi"
-              cpu: "350m"
+              memory: "64Mi"
+              cpu: "250m"
           env:
             - name: ARGOCD_NAMESPACE
               value: openshift-gitops
             - name: IBM_ENTITLEMENT_SECRET
               value: ibm-entitlement-key
             - name: TARGET_NAMESPACE
-              value: "{{.Values.metadata.argocd_app_namespace}}-evt"
+              value: "{{.Values.metadata.argocd_app_namespace}}-emgr"
           command:
             - /bin/sh
             - -c
@@ -36,7 +36,6 @@ spec:
               set -x
 
               # https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0?topic=em-starter-installation
-              export HOME=/tmp
               oc extract secret/"${IBM_ENTITLEMENT_SECRET}" \
                   --namespace "${ARGOCD_NAMESPACE}" \
                   --keys=.dockerconfigjson \
@@ -53,33 +52,11 @@ spec:
                  fi \
               && rm -rf /tmp/.dockerconfigjson \
               && if [ $(oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.endpointPublishingStrategy.type}') = "HostNetwork" ]; then
-                    oc patch namespace default --type=json -p '[{"op":"add","path":"/metadata/labels","value":{"network.openshift.io/policy-group":"ingress"}}]'
+                     oc patch namespace default --type=json -p '[{"op":"add","path":"/metadata/labels","value":{"network.openshift.io/policy-group":"ingress"}}]'
                  fi \
-              && curl -sL https://github.com/IBM/cloud-pak-cli/releases/download/v3.8.0/cloudctl-linux-amd64.tar.gz | tar xzf - -C "/tmp" \
-              && mv -f /tmp/cloudctl-linux-amd64 /tmp/cloudctl \
-              && chmod 755 /tmp/cloudctl \
-              && export PATH=/tmp:$PATH \
-              && cloudctl case save \
-                  --case ibm-netcool-prod \
-                  --outputdir /tmp/cases \
-                  --repo https://raw.githubusercontent.com/IBM/cloud-pak/master/repo/case \
-              && cd /tmp/cases \
-              && tar -xvf /tmp/cases/ibm-netcool-prod*.tgz \
-              && cloudctl case launch  \
-                --case ibm-netcool-prod  \
-                --namespace "${TARGET_NAMESPACE}" \
-                --inventory noiOperatorSetup  \
-                --action install-catalog \
-              && echo "INFO: Case launch install catalog successful." \
-              && cloudctl case launch  \
-                --case ibm-netcool-prod  \
-                --namespace "${TARGET_NAMESPACE}"  \
-                --inventory noiOperatorSetup  \
-                --action install-operator  \
-                --args "--secret noi-registry-secret" \
-              && echo "INFO: Case launch install operator successful." \
+              && echo "INFO: Event Manager prereq configuration successful." \
               || {
-                 echo "ERROR: Event manager install preparation failed."
+                 echo "ERROR: Event Manager prereq configuration failed."
                  exit 1
               }
 

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/05-operator-group.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/05-operator-group.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "{{.Values.metadata.argocd_app_namespace}}-emgr-operator-group"
+  namespace: "{{.Values.metadata.argocd_app_namespace}}-emgr"
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
+spec:
+  targetNamespaces:
+    - "{{.Values.metadata.argocd_app_namespace}}-emgr"

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/09-subscription.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/09-subscription.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  labels:
+    operators.coreos.com/noi.{{.Values.metadata.argocd_app_namespace}}-emgr: ''
+  name: noi
+  namespace: "{{.Values.metadata.argocd_app_namespace}}-emgr"
+spec:
+  channel: v1.5
+  installPlanApproval: Automatic
+  name: noi
+  source: ibm-operator-catalog
+  sourceNamespace: openshift-marketplace

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/99-sync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/99-sync-check-all-csvs.yaml
@@ -3,9 +3,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: post-check-aiops-evt-csvs
+  name: check-aiops-emgr-csvs
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: "110"
+    argocd.argoproj.io/hook: Sync
   namespace: openshift-gitops
 spec:
   template:
@@ -23,7 +24,7 @@ spec:
               cpu: "300m"
           env:
             - name: TARGET_NAMESPACE
-              value: "{{.Values.metadata.argocd_app_namespace}}-evt"
+              value: "{{.Values.metadata.argocd_app_namespace}}-emgr"
           command:
             - /bin/sh
             - -c

--- a/config/cloudpaks/cp4aiops/resources/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/resources/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "3.2.0"

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/10-ai-manager.yaml
@@ -4,7 +4,7 @@ kind: Installation
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "210"
+    argocd.argoproj.io/sync-wave: "200"
   name: ibm-cp-watson-aiops
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/20-sync-check-ai-readiness.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/20-sync-check-ai-readiness.yaml
@@ -3,10 +3,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: post-check-ai-ready
+  name: sync-check-ai-readiness
   annotations:
-    argocd.argoproj.io/sync-wave: "98"
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: "220"
+    argocd.argoproj.io/hook: Sync
   namespace: openshift-gitops
 spec:
   template:

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/99-postsync-certificates.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/99-postsync-certificates.yaml
@@ -5,7 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "99"
+    argocd.argoproj.io/sync-wave: "500"
     argocd.argoproj.io/hook: PostSync
   name: post-cp4aiops-adjust-certs
   namespace: openshift-gitops

--- a/config/cloudpaks/cp4aiops/resources/templates/evt-manager/05-event-manager.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/evt-manager/05-event-manager.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "210"
   creationTimestamp: null
   name: evtmanager
-  namespace: "{{.Values.metadata.argocd_app_namespace}}-evt"
+  namespace: "{{.Values.metadata.argocd_app_namespace}}-emgr"
 spec:
   license:
     accept: true
@@ -35,14 +35,14 @@ spec:
     baseDN: 'dc=mycluster,dc=icp'
     storageSize: 1Gi
     serverType: CUSTOM
-    storageClass: ''
+    storageClass: {{.Values.storageclass.rwo}}
   backupRestore:
     enableAnalyticsBackups: false
   topology:
-    storageClassElasticTopology: ''
+    storageClassElasticTopology: {{.Values.storageclass.rwo}}
     storageSizeElasticTopology: 75Gi
     storageSizeFileObserver: 5Gi
-    storageClassFileObserver: ''
+    storageClassFileObserver: {{.Values.storageclass.rwo}}
     iafCartridgeRequirementsName: ''
     appDisco:
       enabled: false
@@ -98,22 +98,22 @@ spec:
     storageSizeNCOBackup: 5Gi
     enabled: false
     storageSizeNCOPrimary: 5Gi
-    storageClassNCOPrimary: ''
+    storageClassNCOPrimary: {{.Values.storageclass.rwo}}
     storageSizeImpactServer: 5Gi
-    storageClassImpactServer: ''
-    storageClassKafka: ''
+    storageClassImpactServer: {{.Values.storageclass.rwo}}
+    storageClassKafka: {{.Values.storageclass.rwo}}
     storageSizeKafka: 50Gi
-    storageClassCassandraBackup: ''
+    storageClassCassandraBackup: {{.Values.storageclass.rwo}}
     storageSizeCassandraBackup: 50Gi
-    storageClassZookeeper: ''
-    storageClassCouchdb: ''
+    storageClassZookeeper: {{.Values.storageclass.rwo}}
+    storageClassCouchdb: {{.Values.storageclass.rwo}}
     storageSizeZookeeper: 5Gi
     storageSizeCouchdb: 20Gi
-    storageClassCassandraData: ''
+    storageClassCassandraData: {{.Values.storageclass.rwo}}
     storageSizeCassandraData: 50Gi
-    storageClassElastic: ''
-    storageClassImpactGUI: ''
+    storageClassElastic: {{.Values.storageclass.rwo}}
+    storageClassImpactGUI: {{.Values.storageclass.rwo}}
     storageSizeImpactGUI: 5Gi
     storageSizeElastic: 75Gi
-    storageClassNCOBackup: ''
+    storageClassNCOBackup: {{.Values.storageclass.rwo}}
   deploymentType: trial

--- a/config/cloudpaks/cp4aiops/resources/templates/evt-manager/20-sync-check-emgr-group.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/evt-manager/20-sync-check-emgr-group.yaml
@@ -3,9 +3,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: post-check-evt-group
+  name: sync-check-emgr-group
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: "220"
+    argocd.argoproj.io/hook: Sync
   namespace: openshift-gitops
 spec:
   template:
@@ -23,7 +24,7 @@ spec:
               cpu: "300m"
           env:
             - name: TARGET_NAMESPACE
-              value: "{{.Values.metadata.argocd_app_namespace}}-evt"
+              value: "{{.Values.metadata.argocd_app_namespace}}-emgr"
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Closes: #92

Description of changes:
- Matches namespace to suggested namespace in Event Manager docs
- Replace `cloudctl`-based installation with OLM-based installation

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-ga                      92-aiops-evtmgr
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared     92-aiops-evtmgr
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators  92-aiops-evtmgr
cp4aiops-app         https://kubernetes.default.svc  cp4waiops         default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops      92-aiops-evtmgr
cp4aiops-operators   https://kubernetes.default.svc  cp4waiops         default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators   92-aiops-evtmgr
cp4aiops-resources   https://kubernetes.default.svc  cp4waiops         default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources   92-aiops-evtmgr
```
