### PR TITLE
chore: Reverse annotation for Catalog Source in OCP 4.9

### DIFF
--- a/config/cloudpaks/cp-shared/operators/templates/0050-catalogsource-ibm.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0050-catalogsource-ibm.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     argocd.argoproj.io/sync-wave: "50"
-    olm.catalogImageTemplate: "icr.io/cpopen/ibm-operator-catalog:v{kube_major_version}.{kube_minor_version}"
 spec:
   displayName: "IBM Operator Catalog"
   publisher: IBM

--- a/config/cloudpaks/cp4d/install-cognos/templates/resources/cognos.yaml
+++ b/config/cloudpaks/cp4d/install-cognos/templates/resources/cognos.yaml
@@ -11,4 +11,5 @@ spec:
   license:
     accept: true
   namespace: {{.Values.metadata.argocd_app_namespace}}
-  storage_class: "{{.Values.storageclass.rwo}}"
+  storage_class: "{{.Values.storageclass.rwx}}"
+  version: 4.0.5

--- a/config/cloudpaks/cp4d/install-wos/templates/resources/wos.yaml
+++ b/config/cloudpaks/cp4d/install-wos/templates/resources/wos.yaml
@@ -14,3 +14,4 @@ spec:
   scaleConfig: small
   storageClass: {{.Values.storageclass.rwx}}
   type: service
+  version: 4.0.5


### PR DESCRIPTION
Contributes to: #49

Description of changes:
- We found issues where the latest patches for Cloud Paks are not getting reflected in the catalogs labeled with `v1.22`

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

