### PR TITLE
chore: Remove dead code for GitOps preview

### DIFF
--- a/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-ocp-platform.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-ocp-platform.yaml
@@ -43,10 +43,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"

--- a/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-storage-classes.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-storage-classes.yaml
@@ -46,10 +46,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"

--- a/config/argocd-cloudpaks/cp4d/templates/00-presync-adjust-storage-classes.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/00-presync-adjust-storage-classes.yaml
@@ -46,10 +46,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"

--- a/config/argocd-cloudpaks/cp4i/templates/00-presync-adjust-storage-classes.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/00-presync-adjust-storage-classes.yaml
@@ -46,10 +46,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"

--- a/config/cloudpaks/cp4aiops/resources/templates/00-presync-adjust-parameters.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/00-presync-adjust-parameters.yaml
@@ -57,10 +57,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"

--- a/config/cloudpaks/cp4d/install-wkc/templates/operators/00-presync-set-kernel-param.yaml
+++ b/config/cloudpaks/cp4d/install-wkc/templates/operators/00-presync-set-kernel-param.yaml
@@ -40,10 +40,6 @@ spec:
               # Install it from cluster, not from Internet, so airgap scenarios still work
               argo_route=openshift-gitops-server
               argo_secret=openshift-gitops-cluster
-              if [ {{.Values.serviceaccount.argocd_application_controller}} == argocd-cluster-argocd-application-controller ]; then
-                  argo_route=argocd-cluster-server
-                  argo_secret=argocd-cluster-cluster
-              fi
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"


### PR DESCRIPTION
Contributes to: #84 

Description of changes:
- Removes dead code for RH OpenShift GitOps preview from sync hooks

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

