### PR TITLE
bug: Add missing AIOps resources

### DIFF
--- a/config/argocd-cloudpaks/cp4aiops/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4aiops/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "0.5.1"

--- a/config/argocd-cloudpaks/cp4aiops/templates/cp4aiops-resources-app.yaml
+++ b/config/argocd-cloudpaks/cp4aiops/templates/cp4aiops-resources-app.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cp4aiops-resources
   namespace: openshift-gitops
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
+    argocd.argoproj.io/sync-wave: "110"
 spec:
   destination:
     namespace: "{{.Values.metadata.argocd_app_namespace}}"

--- a/config/cloudpaks/cp4aiops/operators/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4aiops/operators/templates/ai-manager/02-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/ai-manager/02-sync-prereqs.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-ai-manager-prereqs
+  name: sync-aimgr-prereqs
   annotations:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/hook: Sync
@@ -16,10 +16,10 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "64Mi"
+              memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "64Mi"
+              memory: "256Mi"
               cpu: "250m"
           env:
             - name: ARGOCD_NAMESPACE
@@ -35,7 +35,8 @@ spec:
               set -eo pipefail
               set -x
 
-              # https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0?topic=em-starter-installation
+              result=0
+              # https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0?topic=manager-starter-installation
               oc extract secret/"${IBM_ENTITLEMENT_SECRET}" \
                   --namespace "${ARGOCD_NAMESPACE}" \
                   --keys=.dockerconfigjson \
@@ -46,7 +47,7 @@ spec:
                         --namespace "${TARGET_NAMESPACE}" \
                         --patch "{\"data\": {\".dockerconfigjson\": \"$(cat /tmp/.dockerconfigjson | base64 -w0)\" }}"
                  else
-                     oc create secret generic ibm-entitlement-key \
+                     oc create secret docker-registry ibm-entitlement-key \
                         --namespace "${TARGET_NAMESPACE}" \
                         --from-file=.dockerconfigjson=/tmp/.dockerconfigjson
                  fi \
@@ -54,11 +55,35 @@ spec:
               && if [ $(oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.endpointPublishingStrategy.type}') = "HostNetwork" ]; then
                     oc patch namespace default --type=json -p '[{"op":"add","path":"/metadata/labels","value":{"network.openshift.io/policy-group":"ingress"}}]'
                  fi \
-              && echo "INFO: AI Manager prereq configuration successful." \
+              || result=1
+
+              oc get ServiceAccount aiops-topology-service-account --namespace "{{.Values.metadata.argocd_app_namespace}}" -o yaml 2> /dev/null \
+              && echo "INFO: Topology service account exists." \
               || {
-                 echo "ERROR: AI Manager prereq configuration failed."
-                 exit 1
+                  echo "INFO: Create the topology service account with the entitlement key pull secret."
+                  cat <<EOF > /tmp/sa.yaml
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: aiops-topology-service-account
+                namespace: "{{.Values.metadata.argocd_app_namespace}}"
+                labels:
+                  managedByUser: "true"
+              imagePullSecrets:
+                - name: ibm-entitlement-key
+              EOF
+                  oc apply -n "{{.Values.metadata.argocd_app_namespace}}" -f /tmp/sa.yaml \
+                  && echo "INFO: Create the topology service account with the entitlement key pull secret." \
+                  || result=1
               }
+
+              if [ ${result} -eq 0 ]; then
+                  echo "INFO: AI Manager prereq configuration successful."
+              else
+                  echo "ERROR: AI Manager prereq configuration failed."
+              fi
+
+              exit ${result}
 
       restartPolicy: Never
       serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}

--- a/config/cloudpaks/cp4aiops/operators/templates/evt-manager/02-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4aiops/operators/templates/evt-manager/02-sync-prereqs.yaml
@@ -46,7 +46,7 @@ spec:
                         --namespace "${TARGET_NAMESPACE}" \
                         --patch "{\"data\": {\".dockerconfigjson\": \"$(cat /tmp/.dockerconfigjson | base64 -w0)\" }}"
                  else
-                     oc create secret generic noi-registry-secret \
+                     oc create secret docker-registry noi-registry-secret \
                         --namespace "${TARGET_NAMESPACE}" \
                         --from-file=.dockerconfigjson=/tmp/.dockerconfigjson
                  fi \

--- a/config/cloudpaks/cp4aiops/resources/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/resources/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/15-patch-orchestrator.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/15-patch-orchestrator.yaml
@@ -1,0 +1,86 @@
+---
+# https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0?topic=manager-starter-installation
+# Add the pull secret to the ibm-aiops-orchestrator operator.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "200"
+  name: cp4aiops-patch-orchestrator
+  namespace: openshift-gitops
+spec:
+  template:
+    spec:
+      containers:
+        - name: config
+          image: quay.io/openshift/origin-cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "96Mi"
+              cpu: "300m"
+          env:
+            - name: TARGET_NAMESPACE
+              value: "{{.Values.metadata.argocd_app_namespace}}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eo pipefail
+              set -x
+
+              result=0
+
+              current_seconds=0
+              operation_limit_seconds=$(( $(date +%s) + 28800 ))
+              orch_found=0
+              while [ ${current_seconds} -lt ${operation_limit_seconds} ]; do
+                orch_found=$(oc get AIOpsAnalyticsOrchestrator aiops -n "${TARGET_NAMESPACE}") \
+                  && orch_found=1 \
+                  || orch_found=0
+
+                if [ ${orch_found} -eq 0 ]; then
+                  echo "INFO: AIOpsAnalyticsOrchestrator not found, waiting some more."
+                  sleep 60
+                else
+                  echo "INFO: AIOpsAnalyticsOrchestrator found."
+                  break;
+                fi
+                current_seconds=$(( $(date +%s) ))
+              done
+
+              if [ ${orch_found} -eq 1 ]; then
+                  if [[ ! "$(oc get AIOpsAnalyticsOrchestrator aiops \
+                                  --namespace "${TARGET_NAMESPACE}" \
+                                  -o jsonpath={.spec.pullSecrets}})" == *ibm-aiops-pull-secret* ]]; then
+                      echo "INFO: Patching AIOpsAnalyticsOrchestrator"
+                      oc patch AIOpsAnalyticsOrchestrator aiops \
+                        --patch='{"spec":{"pullSecrets":["ibm-aiops-pull-secret"]}}' \
+                        --type=merge \
+                        --namespace "${TARGET_NAMESPACE}" \
+                      || result=1
+
+                      oc get deployments \
+                          -l app.kubernetes.io/name=AIOpsAnalyticsOrchestrator \
+                          --namespace "${TARGET_NAMESPACE}" \
+                          -o name | \
+                      while read -r deployment
+                      do
+                          oc rollout restart ${deployment} --namespace "${TARGET_NAMESPACE}" \
+                          && oc rollout status ${deployment} --namespace "${TARGET_NAMESPACE}" \
+                          || result=1
+                      done
+                  else
+                      echo "INFO: AIOpsAnalyticsOrchestrator already patched."
+                  fi
+              fi
+
+              exit ${result}
+
+      restartPolicy: Never
+      serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
+  backoffLimit: 1

--- a/config/cloudpaks/cp4aiops/resources/templates/ai-manager/20-sync-check-ai-readiness.yaml
+++ b/config/cloudpaks/cp4aiops/resources/templates/ai-manager/20-sync-check-ai-readiness.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-check-ai-readiness
+  name: sync-check-aimgr-readiness
   annotations:
     argocd.argoproj.io/sync-wave: "220"
     argocd.argoproj.io/hook: Sync

--- a/docs/install.md
+++ b/docs/install.md
@@ -313,25 +313,19 @@ After completing the list of activities listed in the previous sections, you hav
          --revision "${gitops_branch}" \
          --sync-policy automated \
          --upsert 
-   argocd app wait "${app_name}"
     ```
-
-1. Enable auto-synchronization for the apps automatically added by the previous step. The auto-synchronization is disabled by default in the repo if you want to further configure the applications before starting the synchronization. Note that this step assumes you still have shell variables assigned from previous steps:
-   ```sh
-   argocd app set ${cp}-operators \
-            --sync-policy automated \
-            --self-heal
-   argocd app wait ${cp}-operators \
-            --timeout 1200
-   argocd app set ${cp}-resources \
-            --sync-policy automated \
-            --self-heal
-   argocd app wait ${cp}-resources \
-            --timeout 7200
-   ```
 
 1. List all the applications to see their overall status (this step assumes you still have shell variables assigned from previous steps):
 
    ```sh
    argocd app list -l app.kubernetes.io/instance=${app_name}
+   ```
+
+1. You can also use the ArgoCD command-line interface to wait for the application to be synchronized and healthy:
+
+   ```sh
+   argocd app wait "${app_name}" \
+         --sync \
+         --health \
+         --timeout 3600
    ```

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -7,8 +7,8 @@
   * [Install OpenShift GitOps and policies in the RHACM server](#install-openshift-gitops-and-policies-in-the-rhacm-server)
   * [Install RHACM on OCP cluster via Argo](#install-rhacm-on-ocp-cluster-via-argo)
 - [Using the policies](#using-the-policies)
-  * [Policies:](#policies-)
-  * [Label your clusters:](#label-your-clusters-)
+  * [Policies](#policies)
+  * [Label your clusters](#label-your-clusters)
   * [Examples](#examples)
 - [Contributing](#contributing)
 - [References](#references)
@@ -99,7 +99,7 @@ These steps assume you  logged in to the OCP server with the `oc` command-line i
 
 Once Argo completes synchronizing the applications, your cluster will have policies, placement rules, and placement bindings to deploy Cloud Paks to matching clusters.
 
-### Policies:
+### Policies
 
 - `openshift-gitops-argo-app`: Configures an Argo server with custom health checks for Cloud Paks.
 - `openshift-gitops-cloudpaks-cp-shared`: Deploys common Cloud Pak prerequisites.
@@ -108,7 +108,7 @@ Once Argo completes synchronizing the applications, your cluster will have polic
 - `openshift-gitops-cloudpaks-cp4i`: Deploys the Argo applications for Cloud Pak for Integration.
 - `openshift-gitops-installed`: Deploys OpenShift GitOps.
 
-### Label your clusters:
+### Label your clusters
 
 Labels:
 


### PR DESCRIPTION
Closes: #98

Description of changes:
- Include all pre-installation steps for dealing with entitlement secrets

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                         98-aiops-aimgr
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared     98-aiops-aimgr
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators  98-aiops-aimgr
cp4aiops-app         https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4aiops      98-aiops-aimgr
cp4aiops-operators   https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/operators   98-aiops-aimgr
cp4aiops-resources   https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4aiops/resources   98-aiops-aimgr
```