### PR TITLE
fix: Add missing storage parameters on Cloud Pak for Business Automation

### DIFF
--- a/config/argocd-cloudpaks/cp4a/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4a/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.5.0"
+appVersion: "0.5.1"

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
@@ -34,6 +34,8 @@ spec:
           value: {{.Values.serviceaccount.argocd_application_controller}}
         - name: spec.shared_configuration.sc_deployment_platform
           value: {{.Values.spec.shared_configuration.sc_deployment_platform}}
+        - name: storageclass.block
+          value: {{.Values.storageclass.block}}
         - name: storageclass.bronze
           value: {{.Values.storageclass.bronze}}
         - name: storageclass.gold

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-resources-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-resources-app.yaml
@@ -34,6 +34,8 @@ spec:
           value: {{.Values.serviceaccount.argocd_application_controller}}
         - name: spec.shared_configuration.sc_deployment_platform
           value: {{.Values.spec.shared_configuration.sc_deployment_platform}}
+        - name: storageclass.block
+          value: {{.Values.storageclass.block}}
         - name: storageclass.bronze
           value: {{.Values.storageclass.bronze}}
         - name: storageclass.gold

--- a/config/argocd-cloudpaks/cp4a/values.yaml
+++ b/config/argocd-cloudpaks/cp4a/values.yaml
@@ -10,6 +10,7 @@ spec:
   shared_configuration:
     sc_deployment_platform: ROKS
 storageclass:
+  block: ocs-storagecluster-ceph-rbd
   gold: cp4a-file-retain-gold-gid
   silver: cp4a-file-retain-silver-gid
   bronze: cp4a-file-retain-bronze-gid

--- a/config/cloudpaks/cp4a/resources/Chart.yaml
+++ b/config/cloudpaks/cp4a/resources/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4a/resources/values.yaml
+++ b/config/cloudpaks/cp4a/resources/values.yaml
@@ -7,6 +7,7 @@ spec:
   shared_configuration:
     sc_deployment_platform: ROKS
 storageclass:
+  block: ocs-storagecluster-ceph-rbd
   gold: cp4a-file-retain-gold-gid
   silver: cp4a-file-retain-silver-gid
   bronze: cp4a-file-retain-bronze-gid


### PR DESCRIPTION
Contributes to: #101

Description of changes:
- Adding block storage parameter to Argo applications. Without the parameter, Argo keeps deleting the respective value from the application.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                         104-fix-cp4a-helm
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared     104-fix-cp4a-helm
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators  HEAD
cp4a-app             https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a          104-fix-cp4a-helm
cp4a-operators       https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators       104-fix-cp4a-helm
cp4a-resources       https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources       104-fix-cp4a-helm
```
