### PR TITLE
chore: Use namespace-scoped pull secrets for CP4I

### DIFF
--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4i/templates/cp4i-operator-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/cp4i-operator-app.yaml
@@ -45,12 +45,6 @@ spec:
     automated:
       prune: true
       selfHeal: true
-    retry:
-      limit: 10
-      backoff:
-        duration: 10s
-        factor: 2
-        maxDuration: 1h0m0s
 status:
   health: {}
   summary: {}

--- a/config/argocd-cloudpaks/cp4i/templates/cp4i-resources-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/cp4i-resources-app.yaml
@@ -49,12 +49,6 @@ spec:
     automated:
       prune: true
       selfHeal: true
-    retry:
-      limit: 10
-      backoff:
-        duration: 10s
-        factor: 2
-        maxDuration: 1h0m0s
 status:
   health: {}
   summary: {}

--- a/config/cloudpaks/cp4i/operators/Chart.yaml
+++ b/config/cloudpaks/cp4i/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4i/operators/templates/02-rolebinding/20-role-binding.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/02-rolebinding/20-role-binding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: gitops-cp4i-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "22"
+  namespace: {{.Values.metadata.argocd_app_namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gitops-cp4i-operator
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/config/cloudpaks/cp4i/operators/templates/02-rolebinding/20-role.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/02-rolebinding/20-role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  creationTimestamp: null
+  name: gitops-cp4i-operator
+  namespace: {{.Values.metadata.argocd_app_namespace}}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/0100-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/0100-sync-prereqs.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-cp4i-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+    argocd.argoproj.io/hook: Sync
+  namespace: openshift-gitops
+spec:
+  template:
+    spec:
+      containers:
+        - name: config
+          image: quay.io/openshift/origin-cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          env:
+            - name: ARGOCD_NAMESPACE
+              value: openshift-gitops
+            - name: IBM_ENTITLEMENT_SECRET
+              value: ibm-entitlement-key
+            - name: TARGET_NAMESPACE
+              value: "{{.Values.metadata.argocd_app_namespace}}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eo pipefail
+              set -x
+
+              result=0
+              # https://www.ibm.com/docs/en/cloud-paks/cp-integration/2021.4?topic=installing-applying-your-entitlement-key-online-installation
+              oc extract secret/"${IBM_ENTITLEMENT_SECRET}" \
+                  --namespace "${ARGOCD_NAMESPACE}" \
+                  --keys=.dockerconfigjson \
+                  --to=/tmp \
+                  --confirm \
+              && if oc get secret ibm-entitlement-key --namespace "${TARGET_NAMESPACE}" 2>/dev/null ; then
+                    oc patch secret ibm-entitlement-key \
+                        --namespace "${TARGET_NAMESPACE}" \
+                        --patch "{\"data\": {\".dockerconfigjson\": \"$(cat /tmp/.dockerconfigjson | base64 -w0)\" }}"
+                 else
+                     oc create secret docker-registry ibm-entitlement-key \
+                        --namespace "${TARGET_NAMESPACE}" \
+                        --from-file=.dockerconfigjson=/tmp/.dockerconfigjson
+                 fi \
+              && rm -rf /tmp/.dockerconfigjson \
+              || result=1
+
+              if [ ${result} -eq 0 ]; then
+                  echo "INFO: CP4I prereq configuration successful."
+              else
+                  echo "ERROR: CP4I prereq configuration failed."
+              fi
+
+              exit ${result}
+
+      restartPolicy: Never
+      serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
+  backoffLimit: 1

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/0110-platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/0110-platform-navigator.yaml
@@ -4,12 +4,9 @@ kind: Subscription
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "110"
-  name: >-
-    ibm-integration-platform-navigator
   creationTimestamp: null
+  name: ibm-integration-platform-navigator
   namespace: {{.Values.argocd_app_namespace}}
-  labels:
-    operators.coreos.com/ibm-integration-platform-navigator.ibm-cloudpaks: ''
 spec:
   channel: v5.2
   installPlanApproval: Automatic

--- a/config/cloudpaks/cp4i/operators/templates/04-operators/0120-sync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4i/operators/templates/04-operators/0120-sync-check-all-csvs.yaml
@@ -5,7 +5,8 @@ kind: Job
 metadata:
   name: check-cp4i-csvs
   annotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "120"
   namespace: openshift-gitops
 spec:
   template:

--- a/tests/postbuild/common.sh
+++ b/tests/postbuild/common.sh
@@ -811,10 +811,11 @@ function login_cluster() {
     local managed_ocp_token=${5}
     local retries=${6:-1}
 
-    local result=0
+    local result
 
     for attempt in $(seq 1 "${retries}")
     do
+        result=0
         case ${cluster_type} in
             aws|ocp)
                 login_ocp_cluster "${cluster_name}" "${username}" "${api_key}" \

--- a/tests/postbuild/test.sh
+++ b/tests/postbuild/test.sh
@@ -61,7 +61,7 @@ do
     if grep "/${cloudpak}/" "${branch_delta_output_file}"; then
         labels="${labels},${cloudpak}:${cloudpak}"
         workers=$((workers+3))
-        if [ "${cloudpak}" == "cp4d" ] || [ "${cloudpak}" == "cp4i" ] || [ "${cloudpak}" == "cp4s" ]; then
+        if [ "${cloudpak}" == "cp4d" ]; then
             setup_gps=true
         fi
     fi


### PR DESCRIPTION
Contributes to: #112

Description of changes:
- Add pre-synchronization hook to populate the entitlement key for the Entitled Registry to the target namespace.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

