### PR TITLE
fix: Promote release even if source branch is deleted

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -24,10 +24,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - id: calc
+        if: github.event.pull_request.merged
         name: Determine extent of testing
         run: tests/postbuild/calc-settings.sh "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" "${GITHUB_HEAD_REF}" "${GITHUB_BASE_REF}"
 
       - name: Promote release if test passes
+        if: github.event.pull_request.merged
         run: tests/postbuild/promote-release.sh "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" "${GITHUB_HEAD_REF}" "$(cat test-sh-semver.txt)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Contributes to: #107

Description of changes:
- Remove needless checkout of source branch during promotion
- Fix "close" action

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

