### PR TITLE
chore: Upgrade WAIOps to 3.2.1

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -5,37 +5,6 @@ on:
     branches: [main]
 
 jobs:
-  calc:
-    runs-on: ubuntu-latest
-
-    env:
-      HOME: /root
-      PIPELINE_DEBUG: 1
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Determine extent of testing
-        run: tests/postbuild/calc-settings.sh "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${GITHUB_BASE_REF}"
-
-      - name: Upload global pull secret result
-        uses: actions/upload-artifact@v1
-        with:
-          name: calc
-          path: test-sh-gps.txt
-
-      - name: Upload semver result
-        uses: actions/upload-artifact@v1
-        with:
-          name: calc
-          path: test-sh-labels.txt
-
-      - name: Upload workers result
-        uses: actions/upload-artifact@v1
-        with:
-          name: calc
-          path: test-sh-workers.txt
-
   test:
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip ci' ) }}
     runs-on: ubuntu-latest
@@ -54,13 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: calc
+      - name: Determine extent of testing
+        run: tests/postbuild/calc-settings.sh "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${GITHUB_BASE_REF}"
 
       - name: Ensures target cluster exists
-        run: tests/postbuild/cluster.sh --ensure --wait -t ibmcloud -n "gitops-${GITHUB_HEAD_REF}" --apikey "${IBM_CLOUD_API_KEY}" --workers "$(cat calc/test-sh-workers.txt)" --worker-flavor "c3c.32x64" --global-pull-secret "$(cat calc/test-sh-gps.txt)"
+        run: tests/postbuild/cluster.sh --ensure --wait -t ibmcloud -n "gitops-${GITHUB_HEAD_REF}" --apikey "${IBM_CLOUD_API_KEY}" --workers "$(cat test-sh-workers.txt)" --worker-flavor "c3c.32x64" --global-pull-secret "$(cat test-sh-gps.txt)"
 
       - name: Deploy Argo and Cloud Paks to the cluster
-        run: tests/postbuild/gitops.sh --setup-server -t ibmcloud -n "gitops-${GITHUB_HEAD_REF}" --gitops-repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" --gitops-branch "${GITHUB_HEAD_REF}" --apikey "${IBM_CLOUD_API_KEY}" --application-labels "$(cat calc/test-sh-labels.txt)"
+        run: tests/postbuild/gitops.sh --setup-server -t ibmcloud -n "gitops-${GITHUB_HEAD_REF}" --gitops-repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" --gitops-branch "${GITHUB_HEAD_REF}" --apikey "${IBM_CLOUD_API_KEY}" --application-labels "$(cat test-sh-labels.txt)"

--- a/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.2.0"
+appVersion: "3.2.1"

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/30-sync-certificates.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/30-sync-certificates.yaml
@@ -5,8 +5,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "500"
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: "230"
+    argocd.argoproj.io/hook: Sync
   name: post-cp4aiops-adjust-certs
   namespace: openshift-gitops
 spec:

--- a/config/cloudpaks/cp4aiops/install-emgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-emgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.2.0"
+appVersion: "3.2.1"

--- a/tests/postbuild/calc-settings.sh
+++ b/tests/postbuild/calc-settings.sh
@@ -40,7 +40,6 @@ cleanRun() {
         rm -rf "${WORKDIR}"
     fi
 }
-trap cleanRun EXIT
 
 
 #
@@ -58,13 +57,15 @@ function extract_branch_delta() {
     git clone "${git_repo}" cloudpak-gitops \
     && cd cloudpak-gitops \
     && git config pull.rebase false \
-    result=1
+    || result=1
 
     if [ ${result} -eq 0 ]; then
         git pull origin "${git_source_branch}" || result=1
-        git diff "${git_target_branch}" --name-only | tee "${output_file}" \
+        git diff "${git_target_branch}" origin/main --name-only | tee "${output_file}" \
         && result=0 \
         || result=1
+
+        cat "${branch_delta_output_file}"
     fi
 
     return ${result}

--- a/tests/postbuild/gitops.sh
+++ b/tests/postbuild/gitops.sh
@@ -385,13 +385,6 @@ EOF
             && argocd app wait "${app_name}" \
                 --sync \
                 --health \
-            && argocd app wait "${cp}-operators" \
-                --sync \
-                --health \
-                --timeout 1800 \
-            && argocd app wait "${cp}-resources" \
-                --sync \
-                --health \
                 --timeout 10800 \
             && log "INFO: Synchronization of ${app_name} complete." \
             || cp_result=1


### PR DESCRIPTION
Closes:#122

Description of changes:
- Adjusted setting of ingress certificate to be a Sync rather than PostSync step.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
2022-03-09T14:08:21+0000: INFO: Synchronization of cp4aiops-app complete.
Name:               cp4aiops-app
Project:            default
Server:             https://kubernetes.default.svc/
Namespace:          cp4aiops
URL:                https://openshift-gitops-server-openshift-gitops.gitops-122-cp4aiops-321-1e3af63cfd19e855098d645120e18baf-0000.us-south.containers.appdomain.cloud/applications/cp4aiops-app
Repo:               https://github.com/IBM/cloudpak-gitops
Target:             122-cp4aiops-321
Path:               config/argocd-cloudpaks/cp4aiops
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to 122-cp4aiops-321 (3aa1281)
Health Status:      Healthy

GROUP        KIND         NAMESPACE         NAME            STATUS  HEALTH   HOOK  MESSAGE
argoproj.io  Application  openshift-gitops  cp4aiops-app    Synced                 application.argoproj.io/cp4aiops-app configured
argoproj.io  Application  openshift-gitops  cp4aiops-aimgr  Synced  Healthy        application.argoproj.io/cp4aiops-aimgr configured
argoproj.io  Application  openshift-gitops  cp4aiops-emgr   Synced  Healthy        application.argoproj.io/cp4aiops-emgr configured
```