### PR TITLE
fix: Add retries to CP4I apps

### DIFF
--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4i/templates/0200-cp4i-prereqs-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0200-cp4i-prereqs-app.yaml
@@ -39,3 +39,9 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 6
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 1h0m0s


### PR DESCRIPTION
Contributes to: #147

Description of changes:
- Retries the synchronization of `cp4i-prereqs` for a bit longer to give time for the `ibm-entitlement-key` to be copied to the Cloud Pak namespace.
- Small reordering of steps in the test script to set Argo server settings before installing the Cloud Pak, so that it is easier to get to the Argo CD console before the pipeline completely ends its run.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

