### PR TITLE
chore: Use entitlement key as a gate for Cloud Pak policies on RHACM

### DIFF
--- a/config/cloudpaks/cp4i/install-prereqs/values.yaml
+++ b/config/cloudpaks/cp4i/install-prereqs/values.yaml
@@ -4,6 +4,7 @@ serviceaccount:
   ibm_cloudpaks_installer: ibm-cp4i-installer
 metadata:
   argocd_namespace: openshift-gitops
+  argocd_app_namespace: ibm-cloudpaks
 storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs

--- a/config/rhacm/cloudpaks/Chart.yaml
+++ b/config/rhacm/cloudpaks/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.5.1"
+appVersion: 0.8.4

--- a/config/rhacm/cloudpaks/templates/policy-cp-shared.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp-shared.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp-shared-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: "{{.Values.metadata.argocd_app_namespace}}"

--- a/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp4a-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: '{{ "{{ fromClusterClaim \"cp4a\" }}" }}'

--- a/config/rhacm/cloudpaks/templates/policy-cp4aiops.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4aiops.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp4aiops-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: '{{ "{{ fromClusterClaim \"cp4aiops\" }}" }}'

--- a/config/rhacm/cloudpaks/templates/policy-cp4d.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4d.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp4d-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: '{{ "{{ fromClusterClaim \"cp4d\" }}" }}'

--- a/config/rhacm/cloudpaks/templates/policy-cp4i.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4i.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp4i-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: '{{ "{{ fromClusterClaim \"cp4i\" }}" }}'

--- a/config/rhacm/cloudpaks/templates/policy-cp4s.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4s.yaml
@@ -35,7 +35,9 @@ spec:
                 kind: Application
                 metadata:
                   name: cp4s-app
-                  namespace: openshift-gitops
+                  # Look up used to delay the application of the policy
+                  # until this secret is created
+                  namespace: '{{ "{{ (lookup \"v1\" \"Secret\" \"openshift-gitops\" \"ibm-entitlement-key\").metadata.namespace }}" }}'
                 spec:
                   destination:
                     namespace: '{{ "{{ fromClusterClaim \"cp4s\" }}" }}'

--- a/tests/prebuild/lint.sh
+++ b/tests/prebuild/lint.sh
@@ -73,7 +73,11 @@ log "INFO: Completed yamllint run: ${yl_result}"
 
 log "INFO: Starting helm lint run"
 hl_result=0
-find . -name Chart.yaml | sed "s|/Chart.yaml||g" | xargs helm lint || hl_result=1
+find . -name Chart.yaml \
+    | grep -v /config/rhacm/cloudpaks \
+    | sed "s|/Chart.yaml||g" \
+    | xargs helm lint \
+|| hl_result=1
 log "INFO: Completed helm lint run: ${hl_result}"
 
 log "INFO: Starting helm template run"
@@ -85,7 +89,9 @@ do
     if [ ${htl} -eq 1 ]; then
         ht_result=1;
     fi
-done <<< "$(find . -name Chart.yaml | sed "s|/Chart.yaml||g")"
+done <<< "$(find . -name Chart.yaml \
+    | grep -v /config/rhacm/cloudpaks \
+    | sed "s|/Chart.yaml||g")"
 log "INFO: Completed helm template run: ${ht_result}"
 
 result=$((sc_result+yl_result+hl_result+ht_result))


### PR DESCRIPTION
Contributes to: #154

Description of changes:
- Modify all RHACM policies to require the existence of the ibm-entitlement-key in the openshift-gitops namespace.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

Verification:

Notice how RHACM does not apply the policies for the Cloud Paks when the key is missing:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/3278623/172699961-838b151d-1f2a-4db4-b01d-29fce0afaf73.png">

Details from one of the examples:

<img width="673" alt="image" src="https://user-images.githubusercontent.com/3278623/172700045-02bdda1c-d4a6-49ce-8f02-a75cb5016bcd.png">

