### PR TITLE
chore: Adjust policy severities to RHACM 2.5

### DIFF
--- a/config/rhacm/cloudpaks/Chart.yaml
+++ b/config/rhacm/cloudpaks/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.8.4
+appVersion: 0.8.7

--- a/config/rhacm/cloudpaks/templates/policy-argocd.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-argocd.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-argo-app
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp-shared.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp-shared.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp-shared
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4a.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp4a
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp4aiops.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4aiops.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp4aiops
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp4d.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4d.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp4d
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp4i.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4i.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp4i
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/cloudpaks/templates/policy-cp4s.yaml
+++ b/config/rhacm/cloudpaks/templates/policy-cp4s.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-cloudpaks-cp4s
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*

--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.8.6"
+appVersion: 0.8.7

--- a/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
+++ b/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
@@ -22,7 +22,7 @@ spec:
           name: openshift-gitops-installed
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             exclude:
               - kube-*


### PR DESCRIPTION
Contributes to: #159

Description of changes:
- RHACM 2.5 changed the enumeration for ConfigurationPolicy.spec.severity to full spelling of "med" to "medium" or "Medium"

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

