### PR TITLE
fix: cpctl download timeout on ROKS

### DIFF
--- a/config/cloudpaks/cp4s/Chart.yaml
+++ b/config/cloudpaks/cp4s/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4s/templates/resources/220-openldap.yaml
+++ b/config/cloudpaks/cp4s/templates/resources/220-openldap.yaml
@@ -28,11 +28,6 @@ spec:
               set -eo pipefail
               set -x
 
-              if [ "${IS_ROKS}" == "true" ]; then
-                  echo "WARNING: Waiting for problem resolution in Cloud Pak for Security. The download of the cpctl tool is timing out."
-                  exit 0
-              fi
-
               export HOME=/tmp
 
               result=0
@@ -52,7 +47,15 @@ spec:
                         --from-literal=password="${admin_pwd}"
                 fi \
               && pod_name=$(oc get pod --no-headers -lrun=cp-serviceability | cut -d' ' -f1) \
-              && oc cp ${pod_name}:/opt/bin/linux/cpctl cpctl && chmod +x ./cpctl \
+              && rsync \
+                    --rsh='oc rsh' \
+                    -av \
+                    -c \
+                    --inplace \
+                    --partial \
+                    --append \
+                    --progress $pod_name:/opt/bin/linux/cpctl ./cpctl \
+              && chmod +x ./cpctl \
               || result=1
 
               if [ ${result} -eq 0 ]; then


### PR DESCRIPTION
Closes: #167 

Description of changes:
- Per [new instructions](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10?topic=support-installing-cpctl-utility-access-actions), replace `oc cp` with `rsync...`.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app get cp4s-app
Name:               cp4s-app
Project:            default
Server:             https://kubernetes.default.svc/
Namespace:          openshift-gitops
URL:                https://openshift-gitops-server-openshift-gitops.gitops-167-cp4s-timeout-1e3af63cfd19e855098d645120e18baf-0000.us-south.containers.appdomain.cloud/applications/cp4s-app
Repo:               https://github.com/IBM/cloudpak-gitops
Target:             167-cp4s-timeout
Path:               config/argocd-cloudpaks/cp4s
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to 167-cp4s-timeout (5dc871d)
Health Status:      Healthy

GROUP        KIND         NAMESPACE         NAME                        STATUS     HEALTH   HOOK     MESSAGE
batch        Job          openshift-gitops  pre-cp4s-adjust-parameters  Succeeded           PreSync  job.batch/pre-cp4s-adjust-parameters created
argoproj.io  Application  openshift-gitops  cp4s-app                    Synced                       application.argoproj.io/cp4s-app configured
argoproj.io  Application  openshift-gitops  cp4s-all                    Synced     Healthy           application.argoproj.io/cp4s-all configured
```
