### PR TITLE
feat: RHACM non-admin users

### DIFF
--- a/config/argocd-rhacm/Chart.yaml
+++ b/config/argocd-rhacm/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.8.0"
+appVersion: "0.8.13"

--- a/config/argocd-rhacm/templates/rhacm-seeds-app.yaml
+++ b/config/argocd-rhacm/templates/rhacm-seeds-app.yaml
@@ -19,6 +19,8 @@ spec:
         - /spec/syncPolicy
         - /status
       kind: Application
+    - group: user.openshift.io
+      kind: Group
   project: {{.Values.project}}
   source:
     helm:
@@ -38,6 +40,7 @@ spec:
       selfHeal: true
     syncOptions:
       - PruneLast=true
+      - RespectIgnoreDifferences=true
 status:
   health: {}
   summary: {}

--- a/config/argocd/Chart.yaml
+++ b/config/argocd/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.8.0"
+appVersion: "0.8.13"

--- a/config/argocd/templates/0200-argocd.yaml
+++ b/config/argocd/templates/0200-argocd.yaml
@@ -97,6 +97,27 @@ spec:
           end
         end
         return hs
+    operator.open-cluster-management.io/MultiClusterHub:
+      health.lua: |
+        hs = {}
+        hs.status = "Progressing"
+        hs.message = "Unknown"
+
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.wsStatus
+            if obj.status.phase == "Running" then
+              hs.status = "Healthy"
+            elseif obj.status.phase == "Installing" then
+              hs.status = "Progressing"
+            else
+              hs.status = "Degraded"
+            end
+            return hs
+          end
+        end
+
+        return hs
     core.automation.ibm.com/Cartridge:
       health.lua: |
         hs = {}

--- a/config/argocd/templates/0300-app-project-rhacm-control-plane.yaml
+++ b/config/argocd/templates/0300-app-project-rhacm-control-plane.yaml
@@ -13,6 +13,12 @@ spec:
   clusterResourceWhitelist:
     - group: ''
       kind: Namespace
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: user.openshift.io
+      kind: Group
   description: Configurations for the cluster hosting RHACM
   destinations:
     - name: in-cluster
@@ -21,6 +27,8 @@ spec:
     - namespace: 'policy'
       server: '*'
     - namespace: 'open-cluster-management'
+      server: '*'
+    - namespace: 'rhacm-cloud-creds'
       server: '*'
   namespaceResourceWhitelist:
     - group: argoproj.io
@@ -34,7 +42,11 @@ spec:
     - group: operators.coreos.com
       kind: '*'
     - group: rbac.authorization.k8s.io
-      kind: '*'
+      kind: Role
+    - group: rbac.authorization.k8s.io
+      kind: RoleBinding
+    - group: batch
+      kind: Job
   sourceRepos:
     - {{.Values.repoURL}}
 status: {}

--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.8.7
+appVersion: 0.8.12

--- a/config/rhacm/seeds/templates/0000-namespace-rhacm-creds.yaml
+++ b/config/rhacm/seeds/templates/0000-namespace-rhacm-creds.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    argocd.argoproj.io/managed-by: {{.Values.metadata.argocd_namespace}}
+  name: rhacm-cloud-creds

--- a/config/rhacm/seeds/templates/0000-rhacm-users-group-prereq.yaml
+++ b/config/rhacm/seeds/templates/0000-rhacm-users-group-prereq.yaml
@@ -1,0 +1,58 @@
+---
+# Note that I tried to created this group via declarative approach but, at least as of
+# version 2.3.7, Argo overrides the "users" field of the group, effectively removing
+# users manually added to it, despite our best efforts to set the appropriate
+# "ignoreDifferences" and "RespectIgnoreDifferences" in the respective "Application"
+# resource.
+#
+# If that situation ever changes, remove this Job and add a new YAML for the
+# resource in the repo
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-rhacm-users-group
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/hook: Sync
+  namespace: openshift-gitops
+spec:
+  template:
+    spec:
+      containers:
+        - name: config
+          image: quay.io/openshift/origin-cli:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: GROUP_NAME
+              value: "{{.Values.rhacm_users_group}}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eo pipefail
+              set -x
+
+              result=0
+
+              found=1
+              oc get Group.user.openshift.io ${GROUP_NAME:?} \
+              || found=0
+
+              if [ ${found} -eq 1 ]; then
+                  echo "INFO: Group named ${GROUP_NAME} already exists."
+              else
+                  echo "INFO: Creating group named ${GROUP_NAME:?}." \
+                  && oc adm groups new ${GROUP_NAME} \
+                  && echo "INFO: Created group named ${GROUP_NAME}." \
+                  || result=1
+              fi
+
+              if [ ${result} -eq 1 ]; then
+                  echo "ERROR: Unable to create group named ${GROUP_NAME}."
+              fi
+
+              exit ${result}
+
+      restartPolicy: Never
+      serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
+  backoffLimit: 1

--- a/config/rhacm/seeds/templates/0020-argocd-roles.yaml
+++ b/config/rhacm/seeds/templates/0020-argocd-roles.yaml
@@ -34,3 +34,18 @@ rules:
       - "*"
     verbs:
       - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  creationTimestamp: null
+  name: argocd-rhacm-cluster-role
+rules:
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+    verbs:
+      - create

--- a/config/rhacm/seeds/templates/0020-rhacm-users-creds-roles.yaml
+++ b/config/rhacm/seeds/templates/0020-rhacm-users-creds-roles.yaml
@@ -1,0 +1,35 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  name: rhacm-users-creds
+  namespace: rhacm-cloud-creds
+rules:
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  name: rhacm-users-projects
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projectrequests
+  - verbs:
+      - create
+    apiGroups:
+      - user.openshift.io
+    resources:
+      - groups

--- a/config/rhacm/seeds/templates/0030-argocd-role-bindings.yaml
+++ b/config/rhacm/seeds/templates/0030-argocd-role-bindings.yaml
@@ -32,3 +32,19 @@ subjects:
   - kind: ServiceAccount
     name: "{{.Values.serviceaccount.argocd_application_controller}}"
     namespace: "{{.Values.metadata.argocd_namespace}}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  creationTimestamp: null
+  name: argocd-rhacm-cluster-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-rhacm-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: "{{.Values.serviceaccount.argocd_application_controller}}"
+    namespace: "{{.Values.metadata.argocd_namespace}}"

--- a/config/rhacm/seeds/templates/0030-rhacm-users-creds-bindings.yaml
+++ b/config/rhacm/seeds/templates/0030-rhacm-users-creds-bindings.yaml
@@ -1,0 +1,46 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  name: rhacm-users-projects
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: rhacm-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhacm-users-projects
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  name: rhacm-users-cloud-creds
+  namespace: rhacm-cloud-creds
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: rhacm-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhacm-users-creds
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  name: rhacm-users-cluster-set
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: rhacm-users
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'open-cluster-management:managedclusterset:admin:default'

--- a/config/rhacm/seeds/values.yaml
+++ b/config/rhacm/seeds/values.yaml
@@ -7,4 +7,5 @@ metadata:
   argocd_app_namespace: open-cluster-management
   argocd_namespace: openshift-gitops
   policy_namespace: policy
+rhacm_users_group: rhacm-users
 spec:

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -9,6 +9,7 @@
   * [Policies](#policies)
   * [Label your clusters](#label-your-clusters)
   * [Examples](#examples)
+- [The "rhacm-users" group](#the--rhacm-users--group)
 - [Contributing](#contributing)
 - [References](#references)
 
@@ -25,7 +26,7 @@ This repository contains governance policies and placement rules for Argo CD its
 
 ### Install RHACM on OCP cluster via Argo
 
-These steps assume you  logged in to the OCP server with the `oc` command-line interface:
+These steps assume you logged in to the OCP server with the `oc` command-line interface:
 
 1. [Install the Argo CD command-line interface](https://argoproj.github.io/argo-cd/cli_installation/)
 
@@ -117,6 +118,20 @@ Labeling an OCP cluster with `gitops-branch=main` and `cp4i=ibm-cloudpaks` deplo
 - `openshift-gitops-argo-app`: The Argo configuration is pulled from the `main` branch of this repository.
 `openshift-gitops-cloudpaks-cp-shared`: The Argo configuration is pulled from this repository's `main` branch.
 - `openshift-gitops-cloudpaks-cp4i`: The Cloud Pak is deployed to the namespace `ibm-cloudpaks`
+
+## The "rhacm-users" group
+
+The repository creates the roles and role bindings for a "rhacm-users" user group.
+
+Users in that group will be granted permission to manage clusters in the "default" cluster set, but WITHOUT the permission to manage cloud credentials. That arrangement is ideal for environments where a set of people manages the clusters but not necessarily the underlying cloud accounts.
+
+Refer to OpenShift's [documentation](https://docs.openshift.com/container-platform/4.11/post_installation_configuration/preparing-for-users.html) for more information on user management, such as configuring identity providers and adding users to the Openshift cluster
+
+Once you have the respective users added to the cluster, you can add them to the group via OCP console using the "Add users" option in the panel for the user group (under "User Management" -> "Groups" in the left navigation bar) or using the following command from a terminal window:
+
+```sh
+oc adm groups add-users rhacm-users "${username:?}"
+```
 
 
 ## Contributing


### PR DESCRIPTION
Closes: #169

Description of changes:
- Create access group, roles, and role-bindings for non-superadmin RHACM users

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE                PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops         argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                         169-rhacm-roles
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks            default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared     169-rhacm-roles
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks            default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators  169-rhacm-roles
rhacm-app            https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-rhacm                   169-rhacm-roles
rhacm-cloudpaks      https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/cloudpaks                169-rhacm-roles
rhacm-seeds          https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/seeds                    169-rhacm-roles

```