### PR TITLE
chore: Upgrade RHACM from 2.5 to 2.6

### DIFF
--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.8.12
+appVersion: 0.8.13

--- a/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
+++ b/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
@@ -8,7 +8,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
 spec:
-  channel: release-2.5
+  channel: release-2.6
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators

--- a/tests/postbuild/cluster.sh
+++ b/tests/postbuild/cluster.sh
@@ -17,7 +17,7 @@ oc_cmd=$(type -p oc)
 
 : "${NEW_CLUSTER_TYPE:=fyre-quick-burn}"
 : "${WORKER_FLAVOR:=medium}"
-: "${OCP_VERSION:=4.8}"
+: "${OCP_VERSION:=4.10}"
 
 # In hours
 : "${CLUSTER_EXPIRATION:=12}"


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Closes: #171

Description of changes:
- Update RHACM from 2.5 to 2.6

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

