### PR TITLE
chore: Update WAIOps to 3.5

### DIFF
--- a/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
@@ -13,12 +13,9 @@ description: Cloud Pak for Watson AIOps - AI Manager
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.4.0"
+appVersion: 3.5.0

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/100-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ibm-aiops-orchestrator
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v3.4
+  channel: v3.5
   installPlanApproval: Automatic
   name: ibm-aiops-orchestrator
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4aiops/install-emgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-emgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.0
+appVersion: 3.5.0

--- a/config/cloudpaks/cp4aiops/install-emgr/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4aiops/install-emgr/templates/subscriptions/100-subscription.yaml
@@ -9,7 +9,7 @@ metadata:
   name: noi
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v1.9
+  channel: v1.10
   installPlanApproval: Automatic
   name: noi
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4aiops/install-emgr/values.yaml
+++ b/config/cloudpaks/cp4aiops/install-emgr/values.yaml
@@ -9,7 +9,7 @@ metadata:
   post_install_wait: 2h
 spec:
   deployment_type: trial
-  version: 1.6.5.1
+  version: 1.6.6
 storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs

--- a/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.0
+appVersion: 3.5.0

--- a/config/cloudpaks/cp4aiops/install-ia/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4aiops/install-ia/templates/subscriptions/100-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ibm-infrastructure-automation-operator
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v3.4
+  channel: v3.5
   installPlanApproval: Automatic
   name: ibm-infrastructure-automation-operator
   source: ibm-operator-catalog


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Contributes to: #180

Description of changes:
- Bump up all subscription channels for WAIOps components

Output of AI Manager verification:

```
oc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator,lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && echo "" && oc get BaseUI -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase"
NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS         STORAGECLASSLARGEBLOCK   AGE
cp4aiops    ibm-cp-watson-aiops   Running   Accepted   ibmc-file-gold-gid   ibmc-block-gold          3h14m

KIND                         NAMESPACE   NAME    STATUS
IssueResolutionCore          cp4aiops    aiops   Ready
AIOpsAnalyticsOrchestrator   cp4aiops    aiops   Ready
LifecycleService             cp4aiops    aiops   Ready


KIND     NAMESPACE   NAME              STATUS
BaseUI   cp4aiops    baseui-instance   Ready

KIND        NAMESPACE   NAME             STATUS
AIManager   cp4aiops    aimanager        Completed
AIOpsEdge   cp4aiops    aiopsedge        Configured
ASM         cp4aiops    aiops-topology   OKoc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator,lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && echo "" && oc get BaseUI -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase"
NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS         STORAGECLASSLARGEBLOCK   AGE
cp4aiops    ibm-cp-watson-aiops   Running   Accepted   ibmc-file-gold-gid   ibmc-block-gold          3h14m

KIND                         NAMESPACE   NAME    STATUS
IssueResolutionCore          cp4aiops    aiops   Ready
AIOpsAnalyticsOrchestrator   cp4aiops    aiops   Ready
LifecycleService             cp4aiops    aiops   Ready


KIND     NAMESPACE   NAME              STATUS
BaseUI   cp4aiops    baseui-instance   Ready

KIND        NAMESPACE   NAME             STATUS
AIManager   cp4aiops    aimanager        Completed
AIOpsEdge   cp4aiops    aiopsedge        Configured
ASM         cp4aiops    aiops-topology   OK
```

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                     TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                            180-waiops-350
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared        180-waiops-350
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators     180-waiops-350
cp4aiops-aimgr       https://kubernetes.default.svc  cp4aiops          default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4aiops/install-aimgr  180-waiops-350
cp4aiops-app         https://kubernetes.default.svc  cp4aiops          default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4aiops         180-waiops-350
cp4aiops-emgr        https://kubernetes.default.svc  cp4aiops-emgr     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4aiops/install-emgr   180-waiops-350

```
