### PR TITLE
fix: Argo CD placement rule

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,4 @@
+{
+  "branches": ["main", "alpha"],
+  "plugins": ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/github']
+}

--- a/config/rhacm/cloudpaks/Chart.yaml
+++ b/config/rhacm/cloudpaks/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.8.7
+appVersion: 0.9.1

--- a/config/rhacm/cloudpaks/templates/placement-argocd.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-argocd.yaml
@@ -16,10 +16,9 @@ spec:
       - key: {{.}}
         operator: Exists
         values: []
-      - key: vendor
-        operator: In
-        values:
-          - OpenShift
+      - key: openshiftVersion
+        operator: Exists
+        values: []
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

closes: #182

Description of changes:
- Use "openshiftVersion" instead of "vendor=OpenShift" as a placement rule for Argo CD deployment

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
NAME                 CLUSTER                         NAMESPACE                PROJECT              STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                    TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops         default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                           182-rhacm-rule
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks            default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared       182-rhacm-rule
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks            default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators    182-rhacm-rule
cp4i-apic            https://kubernetes.default.svc  cp4i                     default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-apic      182-rhacm-rule
cp4i-app             https://kubernetes.default.svc  cp4i                     default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4i            182-rhacm-rule
cp4i-mq              https://kubernetes.default.svc  cp4i                     default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-mq        182-rhacm-rule
cp4i-platform        https://kubernetes.default.svc  cp4i                     default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-platform  182-rhacm-rule
cp4i-prereqs         https://kubernetes.default.svc  cp4i                     default              Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-prereqs   182-rhacm-rule
rhacm-app            https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-rhacm                     182-rhacm-rule
rhacm-cloudpaks      https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/cloudpaks                  182-rhacm-rule
rhacm-seeds          https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane  Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/seeds                      182-rhacm-rule
```