### PR TITLE
fix: Fix license code for Platform Navigator in Cloud Pak for Integration

### DIFF
--- a/config/cloudpaks/cp4i/install-platform/templates/0200-platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/install-platform/templates/0200-platform-navigator.yaml
@@ -12,7 +12,7 @@ spec:
   license:
     accept: true
     # https://ibm.biz/integration-licenses
-    license: L-RJON-CD3JJU
+    license: L-RJON-CD3JKX
   mqDashboard: true
   replicas: 1
   storage:


### PR DESCRIPTION
Fix license code for Platform Navigator in Cloud Pak for Integration.

contributes-to: #177

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

