### PR TITLE
fix: Update CP4D version in README to 4.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 ## Contents
 
-- [Overview](#overview)
-  - [IBM Cloud Paks](#ibm-cloud-paks)
-  - [GitOps](#gitops)
-  - [Governance Policies](#governance-policies)
-- [Installation](#installation)
-  - [Individual clusters](#individual-clusters)
-  - [Fleet of clusters with governance](#fleet-of-clusters-with-governance)
-- [Contributing](#contributing)
+- [IBM Cloud Paks - GitOps Demo](#ibm-cloud-paks---gitops-demo)
+  - [Contents](#contents)
+  - [Overview](#overview)
+    - [IBM Cloud Paks](#ibm-cloud-paks)
+    - [GitOps](#gitops)
+    - [Governance Policies](#governance-policies)
+  - [Installation](#installation)
+    - [Individual clusters](#individual-clusters)
+    - [Fleet of clusters with governance](#fleet-of-clusters-with-governance)
+  - [Contributing](#contributing)
 
 ---
 
@@ -32,7 +34,7 @@ Supported versions:
 | Cloud Pak | Version | Installation mode |
 | ----------|---------|-------------------|
 | Cloud Pak for Business Automation | [22.0.2](https://www.ibm.com/docs/en/cloud-paks/cp-biz-automation/22.0.2) | Multi-pattern starter deployment |
-| Cloud Pak for Data | [4.6.0](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
+| Cloud Pak for Data | [4.6.1](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
 | Cloud Pak for Integration | [2022.4](https://www.ibm.com/docs/en/cloud-paks/cp-integration/2022.4) | Online installation |
 | Cloud Pak for Security | [1.10](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10) | Online installation |
 | Cloud Pak for Watson AIOps | [3.6.0](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0) | Online Installation |

--- a/tests/postbuild/gitops.sh
+++ b/tests/postbuild/gitops.sh
@@ -379,12 +379,14 @@ EOF
             && sleep 60 \
             && argocd app wait \
                 --selector app.kubernetes.io/instance="${app_name}" \
-                --health \
                 --operation \
+                --sync \
                 --timeout 10800 \
             && argocd app wait \
                 --selector app.kubernetes.io/instance="${app_name}" \
+                --sync \
                 --operation \
+                --health \
                 --timeout 10800 \
             && log "INFO: Synchronization of ${app_name} complete." \
             || cp_result=1


### PR DESCRIPTION
Contributes to: #191

Description of changes:
- Missing update to README.md
- GitOps deployment not waiting long enough to declare deployment complete

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

