### PR TITLE
feat: Updates to CR versions to match WAIOps 3.7.0 release

### DIFF
--- a/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
@@ -13,9 +13,9 @@ description: Cloud Pak for Watson AIOps - AI Manager
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.13.1
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.6.2
+appVersion: 3.7.0

--- a/config/cloudpaks/cp4waiops/install-aimgr/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4waiops/install-aimgr/templates/subscriptions/100-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ibm-aiops-orchestrator
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v3.6
+  channel: v3.7
   installPlanApproval: Automatic
   name: ibm-aiops-orchestrator
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.2
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.6.2
+appVersion: 3.7.0

--- a/config/cloudpaks/cp4waiops/install-emgr/templates/resources/210-event-manager.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/templates/resources/210-event-manager.yaml
@@ -97,12 +97,13 @@ spec:
   persistence:
     enabled: false
     storageClassCassandraBackup: {{.Values.storageclass.rwo}}
-    storageClassCouchdb: {{.Values.storageclass.rwo}}
     storageClassCassandraData: {{.Values.storageclass.rwo}}
+    storageClassCouchdb: {{.Values.storageclass.rwo}}
     storageClassElastic: {{.Values.storageclass.rwo}}
     storageClassImpactGUI: {{.Values.storageclass.rwo}}
     storageClassImpactServer: {{.Values.storageclass.rwo}}
     storageClassKafka: {{.Values.storageclass.rwo}}
+    storageClassMinio: {{.Values.storageclass.rwo}}
     storageClassNCOBackup: {{.Values.storageclass.rwo}}
     storageClassNCOPrimary: {{.Values.storageclass.rwo}}
     storageClassZookeeper: {{.Values.storageclass.rwo}}

--- a/config/cloudpaks/cp4waiops/install-emgr/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/templates/subscriptions/100-subscription.yaml
@@ -9,7 +9,7 @@ metadata:
   name: noi
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v1.11
+  channel: v1.12
   installPlanApproval: Automatic
   name: noi
   source: ibm-operator-catalog

--- a/config/cloudpaks/cp4waiops/install-emgr/values.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/values.yaml
@@ -9,7 +9,7 @@ metadata:
   post_install_wait: 2h
 spec:
   deployment_type: trial
-  version: 1.6.7
+  version: 1.6.8
 storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs

--- a/config/cloudpaks/cp4waiops/install-ia/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-ia/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.6.0
+appVersion: 3.7.0

--- a/config/cloudpaks/cp4waiops/install-ia/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4waiops/install-ia/templates/subscriptions/100-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ibm-infrastructure-automation-operator
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  channel: v3.6
+  channel: v3.7
   installPlanApproval: Automatic
   name: ibm-infrastructure-automation-operator
   source: ibm-operator-catalog


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

closes: #222

Description of changes:
- Updates to CR versions to match WAIOps 3.7.0 release

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                      TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                             222-cp4waiops-370
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared         222-cp4waiops-370
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators      222-cp4waiops-370
cp4waiops-aimgr      https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-aimgr  222-cp4waiops-370
cp4waiops-app        https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4waiops         222-cp4waiops-370
cp4waiops-emgr       https://kubernetes.default.svc  cp4waiops-emgr    default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-emgr   222-cp4waiops-370
cp4waiops-ia         https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-ia     222-cp4waiops-370
```

```
oc get subscription -A | grep cp4waiops
cp4waiops-emgr        noi                                                                              noi                                               ibm-operator-catalog   v1.12
cp4waiops             aimanager-operator                                                               aimanager-operator                                ibm-operator-catalog   v3.7
cp4waiops             aiopsedge-operator                                                               aiopsedge-operator                                ibm-operator-catalog   v3.7
cp4waiops             asm-operator                                                                     asm-operator                                      ibm-operator-catalog   v3.7
cp4waiops             ibm-aiops-orchestrator                                                           ibm-aiops-orchestrator                            ibm-operator-catalog   v3.7
cp4waiops             ibm-automation-core-v1.3-ibm-operator-catalog-openshift-marketplace              ibm-automation-core                               ibm-operator-catalog   v1.3
cp4waiops             ibm-automation-elastic-v1.3-ibm-operator-catalog-openshift-marketplace           ibm-automation-elastic                            ibm-operator-catalog   v1.3
cp4waiops             ibm-automation-eventprocessing-v1.3-ibm-operator-catalog-openshift-marketplace   ibm-automation-eventprocessing                    ibm-operator-catalog   v1.3
cp4waiops             ibm-automation-flink-v1.3-ibm-operator-catalog-openshift-marketplace             ibm-automation-flink                              ibm-operator-catalog   v1.3
cp4waiops             ibm-automation-v1.3-ibm-operator-catalog-openshift-marketplace                   ibm-automation                                    ibm-operator-catalog   v1.3
cp4waiops             ibm-common-service-operator-v3.23-ibm-operator-catalog-openshift-marketplace     ibm-common-service-operator                       ibm-operator-catalog   v3.23
cp4waiops             ibm-infrastructure-automation-operator                                           ibm-infrastructure-automation-operator            ibm-operator-catalog   v3.7
cp4waiops             ibm-management-cam-install                                                       ibm-management-cam-install                        ibm-operator-catalog   v3.7
cp4waiops             ibm-management-im-install                                                        ibm-management-im-install                         ibm-operator-catalog   v3.7
cp4waiops             ibm-management-kong                                                              ibm-management-kong                               ibm-operator-catalog   v3.7
cp4waiops             ibm-watson-aiops-ui-operator                                                     ibm-watson-aiops-ui-operator                      ibm-operator-catalog   v3.7
cp4waiops             ir-ai-operator                                                                   ibm-aiops-ir-ai                                   ibm-operator-catalog   v3.7
cp4waiops             ir-core-operator                                                                 ibm-aiops-ir-core                                 ibm-operator-catalog   v3.7
cp4waiops             ir-lifecycle-operator                                                            ibm-aiops-ir-lifecycle                            ibm-operator-catalog   v3.7
cp4waiops             redis                                                                            ibm-cloud-databases-redis-operator                ibm-operator-catalog   v1.4
cp4waiops             vault                                                                            ibm-vault-operator                                ibm-operator-catalog   v3.7
```