### PR TITLE
feat: Reduce priority for ibm-operator-catalog catalog source

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -27,6 +27,8 @@ spec:
           value: ${ARGOCD_APP_NAME}
         - name: argocd_app_namespace
           value: ${ARGOCD_APP_NAMESPACE}
+        - name: online_catalog_source_priority
+          value: "{{.Values.online_catalog_source_priority}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
@@ -23,6 +23,8 @@ spec:
   source:
     helm:
       parameters:
+        - name: online_catalog_source_priority
+          value: "{{.Values.online_catalog_source_priority}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -7,6 +7,7 @@ serviceaccount:
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops
+online_catalog_source_priority: -1
 storageclass:
   rwo:
     aws: gp2

--- a/config/cloudpaks/cp-shared/operators/Chart.yaml
+++ b/config/cloudpaks/cp-shared/operators/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "1.1.0"

--- a/config/cloudpaks/cp-shared/operators/templates/0050-catalogsource-ibm.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0050-catalogsource-ibm.yaml
@@ -8,6 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "50"
 spec:
   displayName: "IBM Operator Catalog"
+  priority: {{.Values.online_catalog_source_priority}}
   publisher: IBM
   sourceType: grpc
   image: icr.io/cpopen/ibm-operator-catalog:latest

--- a/config/cloudpaks/cp-shared/operators/values.yaml
+++ b/config/cloudpaks/cp-shared/operators/values.yaml
@@ -3,3 +3,4 @@ metadata:
   argocd_namespace: openshift-gitops
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller
+online_catalog_source_priority: -1


### PR DESCRIPTION
closes: #224

Description of changes:
- Parameterize the priority of the online IBM operator catalog and default it to `-1`, eliminating the current collisions with other eventual IBM catalog sources added to the cluster from sources other than this repository.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

