### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Supported versions:
 | Cloud Pak for Data | [4.6.2](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
 | Cloud Pak for Integration | [2022.4](https://www.ibm.com/docs/en/cloud-paks/cp-integration/2022.4) | Online installation |
 | Cloud Pak for Security | [1.10](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10) | Online installation |
-| Cloud Pak for Watson AIOps | [3.6.2](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.2) | Online Installation |
+| Cloud Pak for Watson AIOps | [3.7.0](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.7.0) | Online Installation |
 
 ### GitOps
 


### PR DESCRIPTION
Contributes to: #222

Description of changes:
- The Cloud Pak table should list Cloud Pak Watson AIOps 3.7.0, not 3.6.2.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

