### PR TITLE
fix: Update Cloud Pak for Data to 4.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Supported versions:
 | Cloud Pak | Version | Installation mode |
 | ----------|---------|-------------------|
 | Cloud Pak for Business Automation | [22.0.2](https://www.ibm.com/docs/en/cloud-paks/cp-biz-automation/22.0.2) | Multi-pattern starter deployment |
-| Cloud Pak for Data | [4.6.2](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
+| Cloud Pak for Data | [4.6.4](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
 | Cloud Pak for Integration | [2022.4](https://www.ibm.com/docs/en/cloud-paks/cp-integration/2022.4) | Online installation |
 | Cloud Pak for Security | [1.10](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10) | Online installation |
 | Cloud Pak for Watson AIOps | [3.7.0](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.7.0) | Online Installation |

--- a/config/argocd-cloudpaks/cp4d/templates/0100-cp4d-app.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/0100-cp4d-app.yaml
@@ -27,6 +27,8 @@ spec:
           value: {{.Values.components}}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
+        - name: metadata.common_services_namespace
+          value: {{.Values.metadata.common_services_namespace}}
         - name: metadata.operators_namespace
           value: {{.Values.metadata.operators_namespace}}
         - name: repoURL

--- a/config/argocd-cloudpaks/cp4d/templates/0200-cp4d-platform-app.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/0200-cp4d-platform-app.yaml
@@ -22,6 +22,8 @@ spec:
           value: {{.Values.components}}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
+        - name: metadata.common_services_namespace
+          value: {{.Values.metadata.common_services_namespace}}
         - name: metadata.operators_namespace
           value: {{.Values.metadata.operators_namespace}}
         - name: repoURL

--- a/config/argocd-cloudpaks/cp4d/values.yaml
+++ b/config/argocd-cloudpaks/cp4d/values.yaml
@@ -6,6 +6,7 @@ serviceaccount:
 metadata:
   argocd_app_namespace: cpd
   argocd_namespace: openshift-gitops
+  common_services_namespace: ibm-common-services
   operators_namespace: cpd-operators
 
 # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=information-determining-which-components-install

--- a/config/cloudpaks/cp4d/Chart.yaml
+++ b/config/cloudpaks/cp4d/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.0
+appVersion: 4.6.4

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-olm.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-olm.yaml
@@ -62,6 +62,7 @@ spec:
               bin/apply-olm apply-olm \
                   --release=${VERSION} \
                   --components=${COMPONENTS} \
+                  --cs_ns=${PROJECT_CPFS_OPS} \
                   --cpd_operator_ns=${PROJECT_CPD_OPS} \
               && bin/get-olm-artifacts \
                   --subscription_ns=${PROJECT_CPFS_OPS}  \

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-platform.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-platform.yaml
@@ -44,9 +44,11 @@ spec:
               bin/setup-instance-ns \
                   --cpd_instance_ns=${PROJECT_CPD_INSTANCE} \
                   --cpd_operator_ns=${PROJECT_CPD_OPS} \
+                  --cs_ns=${PROJECT_CPFS_OPS} \
               && bin/apply-cr \
                   --components=${COMPONENTS} \
                   --release=${VERSION} \
+                  --cs_ns=${PROJECT_CPFS_OPS} \
                   --cpd_instance_ns=${PROJECT_CPD_INSTANCE} \
                   --block_storage_class=${STG_CLASS_BLOCK} \
                   --file_storage_class=${STG_CLASS_FILE} \


### PR DESCRIPTION
closes: #227

Description of changes:
- Update CP4D version to 4.6.4
- Parameterize location of common services

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                  TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                         227-cp4d-464
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared     227-cp4d-464
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators  227-cp4d-464
cp4d-app             https://kubernetes.default.svc  openshift-gitops  default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4d          227-cp4d-464
cp4d-platform        https://kubernetes.default.svc  cp4d              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4d                 227-cp4d-464
```
