### PR TITLE
feat: Make ArgoCD use cluster cert

### DIFF
--- a/config/argocd/Chart.yaml
+++ b/config/argocd/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.31.0"
+appVersion: "0.32.0"

--- a/config/argocd/templates/0200-argocd.yaml
+++ b/config/argocd/templates/0200-argocd.yaml
@@ -553,6 +553,10 @@ spec:
         memory: 128Mi
     route:
       enabled: true
+      tls:
+        # https://access.redhat.com/solutions/6041341
+        insecureEdgeTerminationPolicy: Redirect
+        termination: reencrypt
     service:
       type: ""
   sso:


### PR DESCRIPTION
closes: #100 

Description of changes:
- Use instructions from Red Hat to make the ArgoCD server use the public cluster route: https://access.redhat.com/solutions/6041341

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

