### PR TITLE
fix: Upgrade CP4WAIOps to 3.7.1

### DIFF
--- a/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
@@ -13,9 +13,9 @@ description: Cloud Pak for Watson AIOps - AI Manager
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.7.0
+appVersion: 3.7.1

--- a/config/cloudpaks/cp4waiops/install-aimgr/templates/subscriptions/100-subscription.yaml
+++ b/config/cloudpaks/cp4waiops/install-aimgr/templates/subscriptions/100-subscription.yaml
@@ -7,6 +7,10 @@ metadata:
   name: ibm-aiops-orchestrator
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
+  config:
+    env:
+      - name: REDIS_CHANNEL
+        value: v1.6
   channel: v3.7
   installPlanApproval: Automatic
   name: ibm-aiops-orchestrator

--- a/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.7.0
+appVersion: 3.7.1

--- a/config/cloudpaks/cp4waiops/install-ia/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-ia/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.7.0
+appVersion: 3.7.1


### PR DESCRIPTION
Contributes to: #236 

Description of changes:
- Upgrade CRs to match the WAIOps 3.7.1 release

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                      TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                             236-waiops-371
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared         236-waiops-371
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators      236-waiops-371
cp4waiops-aimgr      https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-aimgr  236-waiops-371
cp4waiops-app        https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4waiops         236-waiops-371
cp4waiops-emgr       https://kubernetes.default.svc  cp4waiops-emgr    default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-emgr   236-waiops-371
```