### PR TITLE
fix: Update Cloud Pak for Data to 4.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supported versions:
 | Cloud Pak | Version | Installation mode |
 | ----------|---------|-------------------|
 | Cloud Pak for Business Automation | [22.0.2](https://www.ibm.com/docs/en/cloud-paks/cp-biz-automation/22.0.2) | Multi-pattern starter deployment |
-| Cloud Pak for Data | [4.6.5](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
+| Cloud Pak for Data | [4.6.6](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=overview) | Online, specialized installation |
 | Cloud Pak for Integration | [2022.4](https://www.ibm.com/docs/en/cloud-paks/cp-integration/2022.4) | Online installation |
 | Cloud Pak for Security | [1.10.12](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10) | Online installation |
 | Cloud Pak for Watson AIOps | [3.7.1](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.7.1) | Online Installation |

--- a/config/argocd-cloudpaks/cp4d/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4d/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.4.0"
+appVersion: "1.4.1"

--- a/config/argocd-cloudpaks/cp4d/values.yaml
+++ b/config/argocd-cloudpaks/cp4d/values.yaml
@@ -16,4 +16,4 @@ storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs
 
-version: 4.6.5
+version: 4.6.6


### PR DESCRIPTION
closes: #239

Description of changes:
- Update version of Cloud Pak for Data

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

