### PR TITLE
fix: Update Cloud Pak for WAIOps 3.7.2

### DIFF
--- a/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-aimgr/Chart.yaml
@@ -13,9 +13,9 @@ description: Cloud Pak for Watson AIOps - AI Manager
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.7.1
+appVersion: 3.7.2

--- a/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
+++ b/config/cloudpaks/cp4waiops/install-emgr/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.7.1
+appVersion: 3.7.2


### PR DESCRIPTION
closes: #241 

Description of changes:
- Updates the version of WAIOps

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                      TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                             241-waiops-372
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared         241-waiops-372
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators      241-waiops-372
cp4waiops-aimgr      https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-aimgr  241-waiops-372
cp4waiops-app        https://kubernetes.default.svc  cp4waiops         default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4waiops         241-waiops-372
cp4waiops-emgr       https://kubernetes.default.svc  cp4waiops-emgr    default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4waiops/install-emgr   241-waiops-372
```