### PR TITLE
fix: Parameterize the installation namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Supported versions:
 
 ### Shared cluster
 
-All Cloud Paks are deployed using dedicated automation foundation instances.
+Starting with the v0.22 release, all Cloud Paks are deployed using dedicated automation foundation instances.
 
 At the root of this configuration, lies a pre-synchronization hook inside the `cp-shared` application, which creates a default "common-service-maps" ConfigMap under the `kube-public` namespace, according to the instructions listed under <https://www.ibm.com/docs/en/cloud-paks/1.0?topic=cfs-installing-cloud-pak-foundational-services-in-multiple-namespaces>
+
+Note that if you want to install a Cloud Pak to a non-default namespace, you must update the parameters to the `cp-shared-app` application to override that default location. 
 
 ### GitOps
 

--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.3.0"
+appVersion: "1.3.1"

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
@@ -1,3 +1,4 @@
+{{ if eq (.Values.dedicated_cs.enabled | toString) "true" }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -36,24 +37,24 @@ spec:
                 namespace: kube-public
               data:
                 common-service-maps.yaml: |
-                  controlNamespace: cs-control
+                  controlNamespace: {{.Values.dedicated_cs.control_namespace}}
                   namespaceMapping:
-                  - map-to-common-service-namespace: {{.Values.namespace_mapping.cp4a}}
+                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4a}}
                     requested-from-namespace:
-                    - {{.Values.namespace_mapping.cp4a}}
-                  - map-to-common-service-namespace: {{.Values.namespace_mapping.cp4d}}
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4a}}
+                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4d}}
                     requested-from-namespace:
-                    - {{.Values.namespace_mapping.cp4d}}
-                  - map-to-common-service-namespace: {{.Values.namespace_mapping.cp4i}}
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4d}}
+                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4i}}
                     requested-from-namespace:
-                    - {{.Values.namespace_mapping.cp4i}}
-                  - map-to-common-service-namespace: {{.Values.namespace_mapping.cp4s}}-cs
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4i}}
+                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4s}}-cs
                     requested-from-namespace:
-                    - {{.Values.namespace_mapping.cp4s}}
-                  - map-to-common-service-namespace: {{.Values.namespace_mapping.cp4waiops}}
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4s}}
+                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4waiops}}
                     requested-from-namespace:
-                    - {{.Values.namespace_mapping.cp4waiops}}
-                    - {{.Values.namespace_mapping.cp4waiops}}-emgr
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4waiops}}
+                    - {{.Values.dedicated_cs.namespace_mapping.cp4waiops}}-emgr
               EOF
               else
                 echo "INFO: ConfigMap common-service-maps already exists."
@@ -62,3 +63,4 @@ spec:
 
       serviceAccountName: {{.Values.serviceaccount.ibm_cloudpaks_installer}}
   backoffLimit: 2
+{{ end }}

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -27,6 +27,20 @@ spec:
           value: ${ARGOCD_APP_NAME}
         - name: argocd_app_namespace
           value: ${ARGOCD_APP_NAMESPACE}
+        - name: dedicated_cs.control_namespace
+          value: "{{.Values.dedicated_cs.control_namespace}}"
+        - name: dedicated_cs.enabled
+          value: "{{.Values.dedicated_cs.enabled}}"
+        - name: dedicated_cs.namespace_mapping.cp4a
+          value: "{{.Values.dedicated_cs.namespace_mapping.cp4a}}"
+        - name: dedicated_cs.namespace_mapping.cp4d
+          value: "{{.Values.dedicated_cs.namespace_mapping.cp4d}}"
+        - name: dedicated_cs.namespace_mapping.cp4i
+          value: "{{.Values.dedicated_cs.namespace_mapping.cp4i}}"
+        - name: dedicated_cs.namespace_mapping.cp4s
+          value: "{{.Values.dedicated_cs.namespace_mapping.cp4s}}"
+        - name: dedicated_cs.namespace_mapping.cp4waiops
+          value: "{{.Values.dedicated_cs.namespace_mapping.cp4waiops}}"
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
         - name: repoURL

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -7,12 +7,15 @@ serviceaccount:
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops
-namespace_mapping:
-  cp4a: cp4a
-  cp4d: cp4d
-  cp4i: cp4i
-  cp4s: cp4s
-  cp4waiops: cp4waiops
+dedicated_cs:
+  control_namespace: cs-control
+  enabled: false
+  namespace_mapping:
+    cp4a: cp4a
+    cp4d: cp4d
+    cp4i: cp4i
+    cp4s: cp4s
+    cp4waiops: cp4waiops
 online_catalog_source_priority: -1
 storageclass:
   rwo:

--- a/docs/install.md
+++ b/docs/install.md
@@ -354,7 +354,7 @@ After completing the list of activities listed in the previous sections, you can
 
    # Note that if you want to use a target namespace that is not the
    # default, you must make the corresponding parameter update to the
-   # cp-shared-app
+   # cp-shared-app application.
    cp_namespace=$cp
 
    app_name=${cp}-app

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,7 +61,7 @@
    ```sh
    oc version --client
 
-   # Client Version: 4.10.45
+   # Client Version: 4.10.60
    ```
 
    Ideally, the client's minor version should be at most one iteration behind the server version. Most commands here are pretty basic and will work with more significant differences, but keep that in mind if you see errors about unrecognized commands and parameters.
@@ -211,17 +211,31 @@ After completing the list of activities listed in the previous sections, you can
     | Revision | HEAD |
     | Cluster URL | <https://kubernetes.default.svc> |
 
+    **Optional**: If you want to deploy a Cloud Pak to a non-default namespace, you must override the default
+    value for the Cloud Paks, using the parameters below:
+
+    | Parameter | (Default) Value |
+    | --------- | --------------- |
+    | dedicated_cs.enabled | true |
+    | dedicated_cs.namespace_mapping.cp4a | cp4a |
+    | dedicated_cs.namespace_mapping.cp4d | cp4d |
+    | dedicated_cs.namespace_mapping.cp4i | cp4i |
+    | dedicated_cs.namespace_mapping.cp4s | cp4s |
+    | dedicated_cs.namespace_mapping.cp4waiops | cp4waiops |
+
 1. After filling out the form details, click the "Create" button
 
 1. (add actual Cloud Pak) Click on the "New App+" button again and fill out the form with values matching the Cloud Pak of your choice, according to the table below:
 
+    Note that if you want to deploy a Cloud Pak to a non-default namespace, you need to make sure you pass the same namespace values used in the optional parameter values for the `cp-shared` application.
+
     | Cloud Pak | Application Name | Path | Namespace |
     | --------- | ---------------- | ---- | --------- |
     | Business Automation | cp4a-app | config/argocd-cloudpaks/cp4a | cp4a |
-    | Integration | cp4i-app | config/argocd-cloudpaks/cp4i | cp4i |
-    | Watson AIOps | cp4waiops-app | config/argocd-cloudpaks/cp4waiops | cp4waiops |
     | Data | cp4d-app | config/argocd-cloudpaks/cp4d | cp4d |
+    | Integration | cp4i-app | config/argocd-cloudpaks/cp4i | cp4i |
     | Security | cp4s-app | config/argocd-cloudpaks/cp4s | cp4s |
+    | Watson AIOps | cp4waiops-app | config/argocd-cloudpaks/cp4waiops | cp4waiops |
 
     For all other fields, use the following values:
 
@@ -249,7 +263,7 @@ After completing the list of activities listed in the previous sections, you can
    ```sh
    oc version --client
 
-   # Client Version: 4.10.35
+   # Client Version: 4.10.60
    ```
 
    Ideally, the client's minor version should be at most one iteration behind the server version. Most commands here are pretty basic and will work with more significant differences, but keep that in mind if you see errors about unrecognized commands and parameters.
@@ -300,6 +314,17 @@ After completing the list of activities listed in the previous sections, you can
 
    ```sh
    cp_namespace=ibm-cloudpaks
+
+   # If you want to override the default target namespace for 
+   # one or more Cloud Paks, you need to adjust the values below
+   # to indicate the desired target namespace.
+   # dedicated_cs.enabled=true
+   cp4a_namespace=cp4a
+   cp4d_namespace=cp4d
+   cp4i_namespace=cp4i
+   cp4s_namespace=cp4s
+   cp4waiops_namespace=cp4waiops
+
    argocd app create cp-shared-app \
          --project default \
          --dest-namespace openshift-gitops \
@@ -308,6 +333,12 @@ After completing the list of activities listed in the previous sections, you can
          --path config/argocd-cloudpaks/cp-shared \
          --helm-set-string argocd_app_namespace="${cp_namespace}" \
          --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
+         --helm-set-string dedicated_cs.enabled="${dedicated_cs.enabled:-false}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4a="${cp4a_namespace}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4d="${cp4d_namespace}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4i="${cp4i_namespace}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4s="${cp4s_namespace}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4waiops="${cp4waiops_namespace}" \
          --sync-policy automated \
          --revision ${gitops_branch:?} \
          --upsert
@@ -320,7 +351,12 @@ After completing the list of activities listed in the previous sections, you can
    # table of Cloud Paks above, such as cp4a-app, cp4i-app, 
    # cp4waiops-app, cp4d-app, etc >>
    cp=cp4i
+
+   # Note that if you want to use a target namespace that is not the
+   # default, you must make the corresponding parameter update to the
+   # cp-shared-app
    cp_namespace=$cp
+
    app_name=${cp}-app
    # app_path=<< choose the respective value from the "path name." 
    # column in the table of Cloud Paks above, such as 

--- a/tests/postbuild/gitops.sh
+++ b/tests/postbuild/gitops.sh
@@ -358,6 +358,11 @@ EOF
         if [ "${cp}" == "rhacm" ]; then
             app_path="config/argocd-rhacm"
         fi
+        local argocd_app_params=()
+        local dedicated_cs_enabled=false
+        if [ "${cp}" == "cp-shared" ]; then
+            argocd_app_params=(--helm-set-string dedicated_cs.enabled="${dedicated_cs_enabled:-false}")
+        fi
         argocd app create "${app_name}" \
             --project default \
             --dest-namespace "${GITOPS_NAMESPACE}" \
@@ -365,6 +370,7 @@ EOF
             --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
             --helm-set-string repoURL="${gitops_repo}" \
             --helm-set-string targetRevision="${gitops_branch}" \
+            "${argocd_app_params[@]}" \
             --path "${app_path}" \
             --repo "${gitops_repo}" \
             --revision "${gitops_branch}" \

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -1,5 +1,6 @@
 ---
 ignore: |
+  config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
   config/argocd-cloudpaks/cp4d/templates/0000-app-namespace.yaml
   config/argocd-cloudpaks/cp4i/templates/0300-cp4i-module-template-app.yaml
   config/argocd-cloudpaks/cp4i/templates/0400-cp4i-client-app.yaml


### PR DESCRIPTION
closes: #244 

Description of changes:
- Make dedicated namespaces default to "false" (need more warning to adopters to adjust to the change)

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

