### PR TITLE
fix: Avoid running cri-o node setup for Cloud Pak for Data running on OCP with a hosted control plane

### DIFF
--- a/config/cloudpaks/cp4d/Chart.yaml
+++ b/config/cloudpaks/cp4d/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.6.5
+appVersion: 4.6.6

--- a/config/cloudpaks/cp4d/templates/0090-sync-cluster-setup.yaml
+++ b/config/cloudpaks/cp4d/templates/0090-sync-cluster-setup.yaml
@@ -46,8 +46,11 @@ spec:
                       OPENSHIFT_TYPE=self-managed
               esac
 
+              hypershift_deployment=$(oc get Infrastructure cluster \
+                -o jsonpath='{.metadata.labels.hypershift\.openshift\.io/managed}')
+
               # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=settings-changing-cri-o-container
-              if [ "${OPENSHIFT_TYPE}" != "roks" ]; then
+              if [ "${OPENSHIFT_TYPE}" != "roks" ] && [ -z "${hypershift_deployment}" ]; then
                   if [[ ${COMPONENTS} =~ cognos_analytics ]] \
                         || [[ ${COMPONENTS} =~ dv ]] \
                         || [[ ${COMPONENTS} =~ db2 ]] \


### PR DESCRIPTION
closes: #249

Description of changes:
- Avoid running cri-o tuning for Cloud Pak for Data in clusters using a hosted control plane.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

From a self-managed AWS HCP cluster, notice how it notices that the cluster has a hosted control plane and does not apply the settings.

<img width="1309" alt="image" src="https://github.com/IBM/cloudpak-gitops/assets/3278623/e2e77d0d-28e5-4233-a67f-7991066f692e">

