### PR TITLE
fix: Improve detection of degraded APIConnectCluster in Cloud Pak for…

### DIFF
--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "2022.4.1"
+appVersion: "2023.2.1"

--- a/config/argocd-cloudpaks/cp4i/templates/0100-cp4i-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0100-cp4i-app.yaml
@@ -39,8 +39,6 @@ spec:
           value: "{{.Values.modules.client}}"
         - name: modules.mq
           value: "{{.Values.modules.mq}}"
-        - name: modules.platform
-          value: "{{.Values.modules.platform}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp4i/templates/0300-cp4i-platform-navigator.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0300-cp4i-platform-navigator.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  name: cp4i-platform
+  namespace: {{ .Values.metadata.argocd_namespace }}
+spec:
+  destination:
+    namespace: {{ .Values.metadata.argocd_app_namespace }}
+    server: 'https://kubernetes.default.svc'
+  ignoreDifferences:
+    - group: argoproj.io
+      jsonPointers:
+        - /spec/source/repoURL
+        - /spec/source/targetRevision
+        - /status
+      kind: Application
+    - group: datapower.ibm.com
+      jsonPointers:
+        - /metadata/labels
+      kind: DataPowerService
+  project: default
+  source:
+    helm:
+      parameters:
+        - name: argocd_app_name
+          value: ${ARGOCD_APP_NAME}
+        - name: argocd_app_namespace
+          value: ${ARGOCD_APP_NAMESPACE}
+        - name: metadata.argocd_app_namespace
+          value: {{ .Values.metadata.argocd_app_namespace }}
+        - name: repoURL
+          value: ${ARGOCD_APP_SOURCE_REPO_URL}
+        - name: serviceaccount.argocd_application_controller
+          value: {{ .Values.serviceaccount.argocd_application_controller }}
+        - name: storageclass.rwo
+          value: {{ .Values.storageclass.rwo }}
+        - name: storageclass.rwx
+          value: {{ .Values.storageclass.rwx }}
+        - name: targetRevision
+          value: ${ARGOCD_APP_SOURCE_TARGET_REVISION}
+    path: config/cloudpaks/cp4i/install-platform
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
@@ -13,7 +13,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "300"
+    argocd.argoproj.io/sync-wave: "301"
   name: cp4i-{{ $module_name }}
   namespace: {{ $argocd_namespace }}
 spec:

--- a/config/argocd-cloudpaks/cp4i/values.yaml
+++ b/config/argocd-cloudpaks/cp4i/values.yaml
@@ -13,5 +13,4 @@ storageclass:
 modules:
   apic: true
   mq: true
-  platform: true
   client: false

--- a/config/argocd/templates/0200-argocd.yaml
+++ b/config/argocd/templates/0200-argocd.yaml
@@ -344,7 +344,11 @@ spec:
                 return hs
               end
               if condition.type == "Pending" and condition.status == "True" then
-                hs.status = "Progressing"
+                if condition.reason == "Error" then
+                  hs.status = "Degraded"
+                else
+                  hs.status = "Progressing"
+                end
                 hs.message = condition.message
                 return hs
               end

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -2,7 +2,7 @@
 ignore: |
   config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
   config/argocd-cloudpaks/cp4d/templates/0000-app-namespace.yaml
-  config/argocd-cloudpaks/cp4i/templates/0300-cp4i-module-template-app.yaml
+  config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
   config/argocd-cloudpaks/cp4i/templates/0400-cp4i-client-app.yaml
   config/argocd-cloudpaks/cp4waiops/templates/000-aimgr-namespace.yaml
   config/argocd-cloudpaks/cp4waiops/templates/020-cloudpaks-aimgr-role.yaml


### PR DESCRIPTION
Improve detection of degraded APIConnectCluster in Cloud Pak for

closes: #253

Description of changes:
- Apply Platform Navigator first, and only then MQ and API Connect (those two can go in parallel)

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                    TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                           253-apic-status
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared       253-apic-status
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators    253-apic-status
cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-apic      253-apic-status
cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4i            253-apic-status
cp4i-mq              https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-mq        253-apic-status
cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-platform  253-apic-status
cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-prereqs   253-apic-status
```