### PR TITLE
fix: Use strings for CP4I modules

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.3.2"
+appVersion: "1.3.3"

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-config-map.yaml
@@ -14,16 +14,13 @@ spec:
         - name: config
           image: quay.io/openshift/origin-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "150m"
-            limits:
-              memory: "64Mi"
-              cpu: "200m"
           env:
             - name: ARGOCD_NAMESPACE
               value: "openshift-gitops"
+            - name: STORAGE_CLASS_OVERRIDE_RWO
+              value: {{ .Values.storageclass.rwo.override }}
+            - name: STORAGE_CLASS_OVERRIDE_RWX
+              value: {{ .Values.storageclass.rwx.override }}
           command:
             - /bin/sh
             - -c
@@ -38,88 +35,104 @@ spec:
                   exit 1
               fi
 
-              storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
-              storage_class_rwx=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
-              if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                  echo "INFO: Cluster has ODF installed, using ODF storage classes."
+              storage_class_rwo="${STORAGE_CLASS_OVERRIDE_RWO}"
+              storage_class_rwx="${STORAGE_CLASS_OVERRIDE_RWX}"
+              if [ -n "${storage_class_rwx}" ]; then
+                  if [ -z "${storage_class_rwo}" ]; then
+                      storage_class_rwo="${storage_class_rwx}"
+                  fi
               else
-                storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
-                storage_class_rwx=$(oc get StorageClasses rook-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
-                if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                  echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
-                fi
-              fi
-
-              # NetApp/Trident support
-              if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ]; then
-                  storage_class_rwx=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-nas" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
-                  storage_class_rwo=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-san" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
-
-                  # If the cluster does not have the dedicated block storage class, the NFS
-                  # driver can address most use cases with the exception of "block" volume
-                  # mode, which is not needed for Cloud Paks
-                  if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                      storage_class_rwo=${storage_class_rwx}
-                  fi
+                  storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
+                  storage_class_rwx=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
                   if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                      echo "INFO: Cluster has ONTAP installed, using ONTAP storage classes."
+                      echo "INFO: Cluster has ODF installed, using ODF storage classes."
+                  else
+                      storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
+                      storage_class_rwx=$(oc get StorageClasses rook-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
+
+                      # If the cluster does not have the dedicated block storage class, the NFS
+                      # driver can address most use cases with the exception of "block" volume
+                      # mode, which is not needed for Cloud Paks
+                      if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          storage_class_rwo=${storage_class_rwx}
+                      fi
+
+                      if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
+                      fi
+                  fi
+
+                  # NetApp/Trident support
+                  if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ]; then
+                      storage_class_rwx=$(oc get storageclass \
+                              -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                          | grep "csi.trident.netapp.io.*ontap-nas" \
+                          | head -n 1 \
+                          | cut -d " " -f 1) || true
+                      storage_class_rwo=$(oc get storageclass \
+                              -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                          | grep "csi.trident.netapp.io.*ontap-san" \
+                          | head -n 1 \
+                          | cut -d " " -f 1) || true
+
+                      # If the cluster does not have the dedicated block storage class, the NFS
+                      # driver can address most use cases with the exception of "block" volume
+                      # mode, which is not needed for Cloud Paks
+                      if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          storage_class_rwo=${storage_class_rwx}
+                      fi
+                      if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          echo "INFO: Cluster has ONTAP installed, using ONTAP storage classes."
+                      fi
+                  fi
+
+                  if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then
+                      if [[ "${api_url}" == *fyre.ibm.com* ]]; then
+                          storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
+                          storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
+                      else
+                          platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
+                          if [ "${platform}" == "AWS" ]; then
+                              ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
+                              if [ -z "${ebs}" ]; then
+                                  ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
+                              fi
+                              efs=$(oc get StorageClasses | grep efs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
+                              if [ -z "${efs}" ]; then
+                                  efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
+                              fi
+                              if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
+                                  storage_class_rwo="${ebs}"
+                                  storage_class_rwx="${efs}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
+                              fi
+                          elif [ "${platform}" == "Azure" ]; then
+                              if oc get StorageClass azure-file 2> /dev/null &&
+                              oc get StorageClass managed-premium 2> /dev/null; then
+                                  storage_class_rwo=managed-premium
+                                  storage_class_rwx=azure-file
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
+                              fi
+                          elif [ "${platform}" == "IBMCloud" ]; then
+                              vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
+                              if [ ${vpc_class} -gt 0 ]; then
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
+                              fi
+                          fi
+                      fi
                   fi
               fi
 
               if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then
-                if [[ "${api_url}" == *fyre.ibm.com* ]]; then
-                  storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
-                  storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
-                else
-                    platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
-                    if [ "${platform}" == "AWS" ]; then
-                        ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
-                        if [ -z "${ebs}" ]; then
-                            ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
-                        fi
-                        efs=$(oc get StorageClasses | grep efs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
-                        if [ -z "${efs}" ]; then
-                            efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
-                        fi
-                        if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
-                            storage_class_rwo="${ebs}"
-                            storage_class_rwx="${efs}"
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
-                            storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
-                        fi
-                    elif [ "${platform}" == "Azure" ]; then
-                        if oc get StorageClass azure-file 2> /dev/null &&
-                          oc get StorageClass managed-premium 2> /dev/null; then
-                            storage_class_rwo=managed-premium
-                            storage_class_rwx=azure-file
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
-                            storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
-                        fi
-                    elif [ "${platform}" == "IBMCloud" ]; then
-                      vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
-                      if [ ${vpc_class} -gt 0 ]; then
-                          storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
-                      else
-                          storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
-                      fi
-                    fi
-                fi
-              fi
-
-              if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then
-                echo "ERROR: Did not find storage classes for target platform."
+                  echo "ERROR: Did not find storage classes for target platform."
                 exit
               fi
 

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
@@ -14,16 +14,13 @@ spec:
         - name: config
           image: quay.io/openshift/origin-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "150m"
-            limits:
-              memory: "64Mi"
-              cpu: "200m"
           env:
             - name: ARGOCD_NAMESPACE
               value: openshift-gitops
+            - name: STORAGE_CLASS_OVERRIDE_RWO
+              value: {{ .Values.storageclass.rwo.override }}
+            - name: STORAGE_CLASS_OVERRIDE_RWX
+              value: {{ .Values.storageclass.rwx.override }}
           command:
             - /bin/sh
             - -c
@@ -37,102 +34,118 @@ spec:
               platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
               cp4a_platform="${platform}"
               if [ "${cp4a_platform}" == "IBMCloud" ]; then
-                cp4a_platform=ROKS
+                  cp4a_platform=ROKS
               else
-                cp4a_platform=OCP
+                  cp4a_platform=OCP
               fi
 
               api_url=$(oc get Infrastructure cluster  -o jsonpath={.status.apiServerURL})
 
-              storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
-              storage_class_rwx=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
-              if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                  echo "INFO: Cluster has ODF installed, using ODF storage classes."
+              storage_class_rwo="${STORAGE_CLASS_OVERRIDE_RWO}"
+              storage_class_rwx="${STORAGE_CLASS_OVERRIDE_RWX}"
+              if [ -n "${storage_class_rwx}" ]; then
+                  if [ -z "${storage_class_rwo}" ]; then
+                      storage_class_rwo="${storage_class_rwx}"
+                  fi
               else
-                storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
-                storage_class_rwx=$(oc get StorageClasses rook-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
-                if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                  echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
-                fi
-              fi
-
-              # NetApp/Trident support
-              if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ]; then
-                  storage_class_rwx=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-nas" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
-                  storage_class_rwo=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-san" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
-
-                  # If the cluster does not have the dedicated block storage class, the NFS
-                  # driver can address most use cases with the exception of "block" volume
-                  # mode, which is not needed for Cloud Paks
-                  if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                      storage_class_rwo=${storage_class_rwx}
-                  fi
-
+                  storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
+                  storage_class_rwx=$(oc get StorageClasses ocs-storagecluster-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
                   if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
-                      echo "INFO: Cluster has ONTAP installed, using ONTAP storage classes."
-                  fi
-              fi
+                      echo "INFO: Cluster has ODF installed, using ODF storage classes."
+                  else
+                      storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
+                      storage_class_rwx=$(oc get StorageClasses rook-cephfs -o name 2> /dev/null | cut -d "/" -f 2) || true
 
-              if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then
-                if [[ "${api_url}" == *fyre.ibm.com* ]]; then
-                  storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
-                  storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
-                else
-                    platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
-                    if [ "${platform}" == "AWS" ]; then
-                        ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
-                        if [ -z "${ebs}" ]; then
-                            ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
-                        fi
-                        efs=$(oc get StorageClasses | grep efs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
-                        if [ -z "${efs}" ]; then
-                            efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
-                        fi
-                        if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
-                            storage_class_rwo="${ebs}"
-                            storage_class_rwx="${efs}"
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
-                            storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
-                        fi
-                    elif [ "${platform}" == "Azure" ]; then
-                        if oc get StorageClass azure-file 2> /dev/null &&
-                          oc get StorageClass managed-premium 2> /dev/null; then
-                            storage_class_rwo=managed-premium
-                            storage_class_rwx=azure-file
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
-                            storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
-                        fi
-                    elif [ "${platform}" == "IBMCloud" ]; then
-                      vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
-                      if [ ${vpc_class} -gt 0 ]; then
-                          storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
-                      else
-                          storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
-                          storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
+                      # If the cluster does not have the dedicated block storage class, the NFS
+                      # driver can address most use cases with the exception of "block" volume
+                      # mode, which is not needed for Cloud Paks
+                      if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          storage_class_rwo=${storage_class_rwx}
                       fi
-                    fi
-                fi
+
+                      if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
+                      fi
+                  fi
+
+                  # NetApp/Trident support
+                  if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ]; then
+                      storage_class_rwx=$(oc get storageclass \
+                            -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                        | grep "csi.trident.netapp.io.*ontap-nas" \
+                        | head -n 1 \
+                        | cut -d " " -f 1) || true
+                      storage_class_rwo=$(oc get storageclass \
+                            -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                        | grep "csi.trident.netapp.io.*ontap-san" \
+                        | head -n 1 \
+                        | cut -d " " -f 1) || true
+
+                      # If the cluster does not have the dedicated block storage class, the NFS
+                      # driver can address most use cases with the exception of "block" volume
+                      # mode, which is not needed for Cloud Paks
+                      if [ -z "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          storage_class_rwo=${storage_class_rwx}
+                      fi
+
+                      if [ -n "${storage_class_rwo}" ] && [ -n "${storage_class_rwx}" ]; then
+                          echo "INFO: Cluster has ONTAP installed, using ONTAP storage classes."
+                      fi
+                  fi
+
+                  if [ -z "${storage_class_rwo}" ] || [ -z "${storage_class_rwx}" ] ; then
+                      if [[ "${api_url}" == *fyre.ibm.com* ]]; then
+                          storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
+                          storage_class_rwx="{{.Values.storageclass.rwx.fyre}}"
+                      else
+                          platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
+                          if [ "${platform}" == "AWS" ]; then
+                              ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
+                              if [ -z "${ebs}" ]; then
+                                  ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
+                              fi
+                              efs=$(oc get StorageClasses | grep efs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
+                              if [ -z "${efs}" ]; then
+                                  efs=$(oc get StorageClasses | grep openshift.org/aws-efs | cut -d " " -f 1) || true
+                              fi
+                              if [ -n "${ebs}" ] && [ -n "${efs}" ]; then
+                                  storage_class_rwo="${ebs}"
+                                  storage_class_rwx="${efs}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.aws}}"
+                              fi
+                          elif [ "${platform}" == "Azure" ]; then
+                              if oc get StorageClass azure-file 2> /dev/null &&
+                                  oc get StorageClass managed-premium 2> /dev/null; then
+                                      storage_class_rwo=managed-premium
+                                      storage_class_rwx=azure-file
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.azure}}"
+                              fi
+                          elif [ "${platform}" == "IBMCloud" ]; then
+                              vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
+                              if [ ${vpc_class} -gt 0 ]; then
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.roksgen2}}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
+                                  storage_class_rwx="{{.Values.storageclass.rwx.roks}}"
+                              fi
+                          fi
+                      fi
+                  fi
               fi
 
               if [ -z "${storage_class_rwo}" ]; then
-                echo "ERROR: Did not find RWO storage classes for target platform."
-                exit
+                  echo "ERROR: Did not find RWO storage classes for target platform."
+                  exit
               fi
 
               if [ -z "${storage_class_rwx}" ]; then
-                echo "ERROR: Did not find RWX storage classes for target platform."
-                exit
+                  echo "ERROR: Did not find RWX storage classes for target platform."
+                  exit
               fi
 
               storage_class_gold=${storage_class_rwx}

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
@@ -47,70 +47,78 @@ spec:
 
               api_url=$(oc get Infrastructure cluster  -o jsonpath={.status.apiServerURL})
 
-              storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
-              if [ -n "${storage_class_rwo}" ]; then
-                  echo "INFO: Cluster has ODF installed, using ODF storage classes."
-              else
-                storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
-                if [ -n "${storage_class_rwo}" ]; then
-                  echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
-                fi
-              fi
-
-              # NetApp/Trident support
-              if [ -z "${storage_class_rwo}" ]; then
-                  storage_class_rwo=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-san" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
-                  # If the cluster does not have the dedicated block storage class, the NFS
-                  # driver can address most use cases with the exception of "block" volume
-                  # mode, which is not needed for Cloud Paks
+              storage_class_rwo="${STORAGE_CLASS_OVERRIDE_RWO}"
+              storage_class_rwx="${STORAGE_CLASS_OVERRIDE_RWX}"
+              if [ -n "${storage_class_rwx}" ]; then
                   if [ -z "${storage_class_rwo}" ]; then
-                    storage_class_rwo=$(oc get storageclass \
-                        -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
-                    | grep "csi.trident.netapp.io.*ontap-nas" \
-                    | head -n 1 \
-                    | cut -d " " -f 1) || true
+                      storage_class_rwo="${storage_class_rwx}"
                   fi
+              else
+                  storage_class_rwo=$(oc get StorageClasses ocs-storagecluster-ceph-rbd -o name 2> /dev/null | cut -d "/" -f 2) || true
                   if [ -n "${storage_class_rwo}" ]; then
-                      echo "INFO: Cluster has ONTAP installed, using ONTAP storage class."
-                  fi
-              fi
-
-              if [ -z "${storage_class_rwo}" ]; then
-                if [[ "${api_url}" == *fyre.ibm.com* ]]; then
-                  storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
-                else
-                    platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
-                    if [ "${platform}" == "AWS" ]; then
-                        ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
-                        if [ -z "${ebs}" ]; then
-                            ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
-                        fi
-                        if [ -n "${ebs}" ]; then
-                            storage_class_rwo="${ebs}"
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
-                        fi
-                    elif [ "${platform}" == "Azure" ]; then
-                        if oc get StorageClass managed-premium 2> /dev/null; then
-                            storage_class_rwo=managed-premium
-                        elif oc get StorageClass managed-csi 2> /dev/null; then
-                            storage_class_rwo=managed-csi
-                        else
-                            storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
-                        fi
-                    elif [ "${platform}" == "IBMCloud" ]; then
-                      vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
-                      if [ ${vpc_class} -gt 0 ]; then
-                          storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
-                      else
-                          storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
+                      echo "INFO: Cluster has ODF installed, using ODF storage classes."
+                  else
+                      storage_class_rwo=$(oc get StorageClasses rook-ceph-block -o name 2> /dev/null | cut -d "/" -f 2) || true
+                      if [ -n "${storage_class_rwo}" ]; then
+                          echo "INFO: Cluster has Ceph installed, using Ceph storage classes."
                       fi
-                    fi
-                fi
+                  fi
+
+                  # NetApp/Trident support
+                  if [ -z "${storage_class_rwo}" ]; then
+                      storage_class_rwo=$(oc get storageclass \
+                            -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                        | grep "csi.trident.netapp.io.*ontap-san" \
+                        | head -n 1 \
+                        | cut -d " " -f 1) || true
+                      # If the cluster does not have the dedicated block storage class, the NFS
+                      # driver can address most use cases with the exception of "block" volume
+                      # mode, which is not needed for Cloud Paks
+                      if [ -z "${storage_class_rwo}" ]; then
+                          storage_class_rwo=$(oc get storageclass \
+                              -o=custom-columns='NAME:metadata.name,PROVISIONER:provisioner,BACKEND-TYPE:parameters.backendType' \
+                          | grep "csi.trident.netapp.io.*ontap-nas" \
+                          | head -n 1 \
+                          | cut -d " " -f 1) || true
+                      fi
+                      if [ -n "${storage_class_rwo}" ]; then
+                          echo "INFO: Cluster has ONTAP installed, using ONTAP storage class."
+                      fi
+                  fi
+
+                  if [ -z "${storage_class_rwo}" ]; then
+                      if [[ "${api_url}" == *fyre.ibm.com* ]]; then
+                          storage_class_rwo="{{.Values.storageclass.rwo.fyre}}"
+                      else
+                          platform=$(oc get Infrastructure cluster  -o jsonpath={.status.platform})
+                          if [ "${platform}" == "AWS" ]; then
+                              ebs=$(oc get StorageClasses | grep ebs.csi.aws.com | head -n 1 | cut -d " " -f 1) || true
+                              if [ -z "${ebs}" ]; then
+                                  ebs=$(oc get StorageClasses | grep kubernetes.io/aws-ebs | cut -d " " -f 1) || true
+                              fi
+                              if [ -n "${ebs}" ]; then
+                                  storage_class_rwo="${ebs}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.aws}}"
+                              fi
+                          elif [ "${platform}" == "Azure" ]; then
+                              if oc get StorageClass managed-premium 2> /dev/null; then
+                                  storage_class_rwo=managed-premium
+                              elif oc get StorageClass managed-csi 2> /dev/null; then
+                                  storage_class_rwo=managed-csi
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.azure}}"
+                              fi
+                          elif [ "${platform}" == "IBMCloud" ]; then
+                              vpc_class=$(oc get StorageClass | grep -c "ibmc-vpc" || result=0)
+                              if [ ${vpc_class} -gt 0 ]; then
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roksgen2}}"
+                              else
+                                  storage_class_rwo="{{.Values.storageclass.rwo.roks}}"
+                              fi
+                          fi
+                      fi
+                  fi
               fi
 
               if [ -z "${storage_class_rwo}" ]; then

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -43,6 +43,10 @@ spec:
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4waiops}}"
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
+        - name: storageclass.rwo.override
+          value: "{{.Values.storageclass.rwo.override}}"
+        - name: storageclass.rwx.override
+          value: "{{.Values.storageclass.rwx.override}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
@@ -29,6 +29,10 @@ spec:
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller
           value: {{.Values.serviceaccount.argocd_application_controller}}
+        - name: storageclass.rwo.override
+          value: "{{.Values.storageclass.rwo.override}}"
+        - name: storageclass.rwx.override
+          value: "{{.Values.storageclass.rwx.override}}"
         - name: targetRevision
           value: ${ARGOCD_APP_SOURCE_TARGET_REVISION}
     path: config/cloudpaks/cp-shared/operators

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -19,12 +19,14 @@ dedicated_cs:
 online_catalog_source_priority: -1
 storageclass:
   rwo:
+    override:
     aws: gp2
     azure: ocs-storagecluster-ceph-rbd
     fyre: rook-ceph-block
     roks: ibmc-block-gold
     roksgen2: ocs-storagecluster-ceph-rbd
   rwx:
+    override:
     aws: ocs-storagecluster-cephfs
     azure: ocs-storagecluster-cephfs
     fyre: rook-cephfs

--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
@@ -7,7 +7,7 @@
 {{- $targetRevision := .Values.targetRevision -}}
 {{- range $module_name, $module_enabled := .Values.modules }}
 {{- if not (eq $module_name "client") }}
-{{- if eq ( default false $module_enabled ) true  }}
+{{- if eq ( default "false" $module_enabled | toString ) "true" }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/config/argocd-cloudpaks/cp4i/templates/0400-cp4i-client-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0400-cp4i-client-app.yaml
@@ -1,5 +1,5 @@
-{{- $client := .Values.modules.client }}
-{{- if eq ( default false $client ) true  }}
+{{- $client := .Values.modules.client | toString }}
+{{- if eq ( default "false" $client ) "true" }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/config/argocd-cloudpaks/cp4i/values.yaml
+++ b/config/argocd-cloudpaks/cp4i/values.yaml
@@ -11,6 +11,6 @@ storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs
 modules:
-  apic: true
-  mq: true
-  client: false
+  apic: "true"
+  mq: "true"
+  client: "false"


### PR DESCRIPTION
closes: #276

Description of changes:
- Uses string values for module selection in cp4i-app

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                    TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                           276-cp4i-boolean
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared       276-cp4i-boolean
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators    276-cp4i-boolean
cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-apic      276-cp4i-boolean
cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4i            276-cp4i-boolean
cp4i-mq              https://kubernetes.default.svc  cp4i              default               OutOfSync  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-mq        276-cp4i-boolean
cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-platform  276-cp4i-boolean
cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-prereqs   276-cp4i-boolean

```