### PR TITLE
fix: Increase backoff retries and duration for CP4I

### DIFF
--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4i/templates/0100-cp4i-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0100-cp4i-app.yaml
@@ -56,6 +56,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 2h0m0s
 status:
   health: {}
   summary: {}

--- a/config/argocd-cloudpaks/cp4i/templates/0300-cp4i-platform-navigator.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0300-cp4i-platform-navigator.yaml
@@ -48,3 +48,9 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 2h0m0s

--- a/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0301-cp4i-module-template-app.yaml
@@ -58,6 +58,12 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 1h0m0s
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
contributes-to: #284

Description of changes:
- Increase backoff duration for CP4I Applications

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                 CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                    TARGET
argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                           284-longer-sync
cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared       284-longer-sync
cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators    284-longer-sync
cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-apic      284-longer-sync
cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4i            284-longer-sync
cp4i-mq              https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-mq        284-longer-sync
cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-platform  284-longer-sync
cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-prereqs   284-longer-sync
```