### PR TITLE
fix: Remove dedicated ns for Data, BA, and AIOps

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.3.3"
+appVersion: "1.3.4"

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
@@ -39,18 +39,12 @@ spec:
                 common-service-maps.yaml: |
                   controlNamespace: {{.Values.dedicated_cs.control_namespace}}
                   namespaceMapping:
-                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4d}}
-                    requested-from-namespace:
-                    - {{.Values.dedicated_cs.namespace_mapping.cp4d}}
                   - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4i}}
                     requested-from-namespace:
                     - {{.Values.dedicated_cs.namespace_mapping.cp4i}}
                   - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4s}}-cs
                     requested-from-namespace:
                     - {{.Values.dedicated_cs.namespace_mapping.cp4s}}
-                  - map-to-common-service-namespace: {{.Values.dedicated_cs.namespace_mapping.cp4aiops}}
-                    requested-from-namespace:
-                    - {{.Values.dedicated_cs.namespace_mapping.cp4aiops}}
               EOF
               else
                 echo "INFO: ConfigMap common-service-maps already exists."

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
@@ -136,7 +136,7 @@ spec:
               || oc create configmap "${config_map_name}" \
                   --from-literal=cluster_domain="${ocp_domain}" \
                   --from-literal=dedicated_cs_enabled="{{.Values.dedicated_cs.enabled}}" \
-                  --from-literal=dedicated_cs_namespace="{{.Values.dedicated_cs.enabled}}" \
+                  --from-literal=dedicated_cs_namespace="{{.Values.dedicated_cs.control_namespace}}" \
                   --from-literal=roks_authentication="${cp4s_roks_auth}" \
                   --from-literal=serviceaccount.argocd_application_controller="{{.Values.serviceaccount.argocd_application_controller}}" \
                   --from-literal=storageclass.rwo="${storage_class_rwo}"

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -31,16 +31,10 @@ spec:
           value: "{{.Values.dedicated_cs.control_namespace}}"
         - name: dedicated_cs.enabled
           value: "{{.Values.dedicated_cs.enabled}}"
-        - name: dedicated_cs.namespace_mapping.cp4a
-          value: "{{.Values.dedicated_cs.namespace_mapping.cp4a}}"
-        - name: dedicated_cs.namespace_mapping.cp4d
-          value: "{{.Values.dedicated_cs.namespace_mapping.cp4d}}"
         - name: dedicated_cs.namespace_mapping.cp4i
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4i}}"
         - name: dedicated_cs.namespace_mapping.cp4s
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4s}}"
-        - name: dedicated_cs.namespace_mapping.cp4aiops
-          value: "{{.Values.dedicated_cs.namespace_mapping.cp4aiops}}"
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
         - name: storageclass.rwo.override

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -11,11 +11,8 @@ dedicated_cs:
   control_namespace: cs-control
   enabled: false
   namespace_mapping:
-    cp4a: cp4a
-    cp4d: cp4d
     cp4i: cp4i
     cp4s: cp4s
-    cp4aiops: cp4aiops
 online_catalog_source_priority: -1
 storageclass:
   rwo:

--- a/config/cloudpaks/cp4s/templates/resources/200-cp4s-threat-mgmt.yaml
+++ b/config/cloudpaks/cp4s/templates/resources/200-cp4s-threat-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
     repository: cp.icr.io/cp/cp4s
     repositoryType: entitled
     roksAuthentication: {{.Values.roks_authentication}}
-{{ if eq ( default "false" .Values.dedicated_cs.enabled ) "true" }}
+{{ if eq (.Values.dedicated_cs.enabled  | toString) "true" }}
     CSNamespace: "{{.Values.metadata.argocd_app_namespace}}-cs"
 {{ end }}
   threatManagementCapabilities:

--- a/docs/install.md
+++ b/docs/install.md
@@ -211,21 +211,19 @@ After completing the list of activities listed in the previous sections, you can
     | Revision | HEAD |
     | Cluster URL | <https://kubernetes.default.svc> |
 
-    **Optional**: If you want to deploy a Cloud Pak to a non-default namespace, you must override the default
-    value for the Cloud Paks, using the parameters below:
+    **Optional**: If you want to deploy Cloud Pak for Integration or Cloud Pak for Security to a non-default namespace, you must override the default value for the Cloud Paks, using the parameters below:
 
     | Parameter | (Default) Value |
     | --------- | --------------- |
     | dedicated_cs.enabled | true |
-    | dedicated_cs.namespace_mapping.cp4a | cp4a |
-    | dedicated_cs.namespace_mapping.cp4d | cp4d |
     | dedicated_cs.namespace_mapping.cp4i | cp4i |
     | dedicated_cs.namespace_mapping.cp4s | cp4s |
-    | dedicated_cs.namespace_mapping.cp4aiops | cp4aiops |
 
-1. After filling out the form details, click the "Create" button
+    Note that Cloud Pak for Data and Cloud Pak for Business Automation do not have this setting - because they enable dedicated Foundation Service namespace by default. Cloud Pak for AIOps does not have this setting either, because it does not support dedicated Foundation Service namespaces.
 
-1. (add actual Cloud Pak) Click on the "New App+" button again and fill out the form with values matching the Cloud Pak of your choice, according to the table below:
+2. After filling out the form details, click the "Create" button
+
+3. (add actual Cloud Pak) Click on the "New App+" button again and fill out the form with values matching the Cloud Pak of your choice, according to the table below:
 
     Note that if you want to deploy a Cloud Pak to a non-default namespace, you need to make sure you pass the same namespace values used in the optional parameter values for the `cp-shared` application.
 
@@ -248,13 +246,13 @@ After completing the list of activities listed in the previous sections, you can
     | Revision | HEAD |
     | Cluster URL | <https://kubernetes.default.svc> |
 
-1. After filling out the form details, click the "Create" button
+4. After filling out the form details, click the "Create" button
 
-1. Under "Parameters," set the values for the fields `storageclass.rwo` and `storageclass.rwx` with the appropriate storage classes. For OpenShift Container Storage, the values will be `ocs-storagecluster-ceph-rbd` and `ocs-storagecluster-cephfs`, respectively.
+5. Under "Parameters," set the values for the fields `storageclass.rwo` and `storageclass.rwx` with the appropriate storage classes. For OpenShift Container Storage, the values will be `ocs-storagecluster-ceph-rbd` and `ocs-storagecluster-cephfs`, respectively.
 
-1. After filling out the form details, click the "Create" button
+6. After filling out the form details, click the "Create" button
 
-1. Wait for the synchronization to complete.
+7. Wait for the synchronization to complete.
 
 ### Using a terminal
 
@@ -335,11 +333,8 @@ After completing the list of activities listed in the previous sections, you can
          --helm-set-string argocd_app_namespace="${cp_namespace}" \
          --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
          --helm-set-string dedicated_cs.enabled="${dedicated_cs_enabled:-false}" \
-         --helm-set-string dedicated_cs.namespace_mapping.cp4a="${cp4a_namespace}" \
-         --helm-set-string dedicated_cs.namespace_mapping.cp4d="${cp4d_namespace}" \
          --helm-set-string dedicated_cs.namespace_mapping.cp4i="${cp4i_namespace}" \
          --helm-set-string dedicated_cs.namespace_mapping.cp4s="${cp4s_namespace}" \
-         --helm-set-string dedicated_cs.namespace_mapping.cp4aiops="${cp4aiops_namespace}" \
          --sync-policy automated \
          --revision ${gitops_branch:?} \
          --upsert


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

closes: #286

Description of changes:
- Remove configuration for dedicated namespace for Cloud Pak for Data. It has native support for it.
- Remove configuration for dedicated namespace for Cloud Pak for Business Automation. It has native support for it.
- Remove configuration for dedicated namespace for Cloud Pak for AIOps. It does not support it.

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

