### PR TITLE
fix: Update AIOps to 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Supported versions:
 | Cloud Pak for Data | [4.7.2](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.7.x?topic=overview) | Online, specialized installation |
 | Cloud Pak for Integration | [2023.2](https://www.ibm.com/docs/en/cloud-paks/cp-integration/2023.2) | Online installation |
 | Cloud Pak for Security | [1.10.15](https://www.ibm.com/docs/en/cloud-paks/cp-security/1.10) | Online installation |
-| Cloud Pak for AIOps\* | [4.2.0](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/4.2.0) | Starter Installation |
+| Cloud Pak for AIOps\* | [4.2.1](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/4.2.1) | Starter Installation |
 
-\* Starting with release 4.2.0, Cloud Pak for Watson AIOps was renamed Cloud Pak for AIOps.
+\* Starting with release 4.2.0, Cloud Pak for Watson AIOps was renamed Cloud Pak for AIOps, which required renaming several folders and labels from `cp4waiops` to `cp4aiops`. You can see all changes in [pull request #281](https://github.com/IBM/cloudpak-gitops/pull/281).
 
 ### Shared cluster
 

--- a/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.16.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.2.0
+appVersion: 4.2.1

--- a/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.16.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.2.0
+appVersion: 4.2.1


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

closes: #292

Description of changes:
- Updates Cloud Pak for AIOps to release 4.2.1

Output of `argocd app list` command or screenshot of the ArgoCD Application synchronization window showing successful application of changes in this branch.

