### PR TITLE
fix: Fix RHACM app project location

### DIFF
--- a/config/argocd-rhacm/Chart.yaml
+++ b/config/argocd-rhacm/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.17.0"
+appVersion: "0.18.0"

--- a/config/argocd-rhacm/templates/0000-app-project-rhacm-control-plane.yaml
+++ b/config/argocd-rhacm/templates/0000-app-project-rhacm-control-plane.yaml
@@ -3,7 +3,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "300"
+    argocd.argoproj.io/sync-wave: "000"
   creationTimestamp: null
   labels:
     control-plane: rhacm
@@ -24,7 +24,7 @@ spec:
   description: Configurations for the cluster hosting RHACM
   destinations:
     - name: in-cluster
-      namespace: 'openshift-gitops'
+      namespace: '{{ .Values.metadata.argocd_namespace }}'
       server: https://kubernetes.default.svc
     - namespace: 'policy'
       server: '*'
@@ -37,6 +37,8 @@ spec:
   namespaceResourceWhitelist:
     - group: argoproj.io
       kind: Application
+    - group: argoproj.io
+      kind: AppProject
     - group: apps.open-cluster-management.io
       kind: '*'
     - group: cluster.open-cluster-management.io

--- a/config/argocd-rhacm/templates/0001-namespace-rhacm.yaml
+++ b/config/argocd-rhacm/templates/0001-namespace-rhacm.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   labels:
     argocd.argoproj.io/managed-by: {{.Values.metadata.argocd_namespace}}
   name: open-cluster-management

--- a/config/argocd-rhacm/templates/0100-rhacm-app.yaml
+++ b/config/argocd-rhacm/templates/0100-rhacm-app.yaml
@@ -40,6 +40,12 @@ spec:
       selfHeal: true
     syncOptions:
       - PruneLast=true
+    retry:
+      limit: 8
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 1h0m0s
 status:
   health: {}
   summary: {}

--- a/config/argocd-rhacm/templates/0100-rhacm-seeds-app.yaml
+++ b/config/argocd-rhacm/templates/0100-rhacm-seeds-app.yaml
@@ -43,6 +43,12 @@ spec:
     syncOptions:
       - PruneLast=true
       - RespectIgnoreDifferences=true
+    retry:
+      limit: 8
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 1h0m0s
 status:
   health: {}
   summary: {}

--- a/config/argocd/Chart.yaml
+++ b/config/argocd/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.21.0"
+appVersion: "0.30.6"

--- a/config/argocd/templates/0010-app-project-argocd-control-plane.yaml
+++ b/config/argocd/templates/0010-app-project-argocd-control-plane.yaml
@@ -5,12 +5,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "10"
   creationTimestamp: null
-  labels:
-    control-plane: rhacm
   name: argocd-control-plane
   namespace: openshift-gitops
 spec:
-  description: Configurations for the cluster hosting RHACM
+  description: Configurations for the cluster hosting ArgoCD
   destinations:
     - name: 'in-cluster'
       namespace: 'openshift-gitops'

--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.0
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,6 +89,15 @@
    EOF
    ```
 
+   Wait until the ArgoCD instance appears as ready in the `openshift-gitops` namespace.
+
+   ```sh
+    oc wait ArgoCD openshift-gitops \
+        -n openshift-gitops \
+        --for=jsonpath='{.status.phase}'=Available \
+        --timeout=600s
+   ```
+
 ---
 
 ## Obtain an entitlement key
@@ -305,8 +314,9 @@ After completing the list of activities listed in the previous sections, you can
          --helm-set-string targetRevision="${gitops_branch}" \
          --revision ${gitops_branch:?} \
          --sync-policy automated \
-         --upsert 
-    ```
+         --upsert \
+   && argocd app wait argo-app
+   ```
 
 1. Add the `cp-shared` application. (this step assumes you still have the shell variables assigned from previous steps) :
 


### PR DESCRIPTION
Contributes to: #294

Description of changes:
- Includes RHACM control plane project in the rhacm-app
- Updates documentation to account for `argo-app` not being installed

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                              CLUSTER                         NAMESPACE                PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                    TARGET
openshift-gitops/argo-app         https://kubernetes.default.svc  openshift-gitops         argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd           294-rhacm-appproject
openshift-gitops/rhacm-app        https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-rhacm     294-rhacm-appproject
openshift-gitops/rhacm-cloudpaks  https://kubernetes.default.svc  openshift-gitops         rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/cloudpaks  294-rhacm-appproject
openshift-gitops/rhacm-seeds      https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/seeds      294-rhacm-appproject
```
