### PR TITLE
feat: Update OpenShift GitOps to 1.10

### DIFF
--- a/config/argocd/Chart.yaml
+++ b/config/argocd/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.30.6"
+appVersion: "0.31.0"

--- a/config/argocd/templates/0200-argocd.yaml
+++ b/config/argocd/templates/0200-argocd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   annotations:
@@ -27,15 +27,6 @@ spec:
         cpu: 250m
         memory: 1Gi
     sharding: {}
-  dex:
-    openShiftOAuth: true
-    resources:
-      limits:
-        cpu: 500m
-        memory: 256Mi
-      requests:
-        cpu: 250m
-        memory: 128Mi
   grafana:
     enabled: false
     ingress:
@@ -86,9 +77,10 @@ spec:
       requests:
         cpu: 250m
         memory: 256Mi
-  resourceCustomizations: |
-    argoproj.io/Application:
-      health.lua: |
+  resourceHealthChecks:
+    - group: argoproj.io
+      kind: Application
+      check: |
         hs = {}
         hs.status = "Progressing"
         hs.message = ""
@@ -101,8 +93,9 @@ spec:
           end
         end
         return hs
-    multicluster.odf.openshift.io/MirrorPeer:
-      health.lua: |
+    - group: multicluster.odf.openshift.io
+      kind: MirrorPeer
+      check: |
         hs = {}
         hs.status = "Progressing"
         hs.message = "Unknown"
@@ -121,8 +114,9 @@ spec:
         end
 
         return hs
-    ocs.openshift.io/StorageCluster:
-      health.lua: |
+    - group: ocs.openshift.io
+      kind: StorageCluster
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.conditions ~= nil then
@@ -143,8 +137,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    odf.openshift.io/StorageSystem:
-      health.lua: |
+    - group: odf.openshift.io
+      kind: StorageSystem
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.conditions ~= nil then
@@ -170,8 +165,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    ramendr.openshift.io/DRPlacementControl:
-      health.lua: |
+    - group: ramendr.openshift.io
+      kind: DRPlacementControl
+      check: |
         hs = {}
 
         if obj.status ~= nil then
@@ -188,8 +184,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    ramendr.openshift.io/DRPolicy:
-      health.lua: |
+    - group: ramendr.openshift.io
+      kind: DRPolicy
+      check: |
         hs = {}
 
         if obj.status ~= nil then
@@ -211,8 +208,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    operator.open-cluster-management.io/MultiClusterHub:
-      health.lua: |
+    - group: operator.open-cluster-management.io
+      kind: MultiClusterHub
+      check: |
         hs = {}
         hs.status = "Progressing"
         hs.message = "Unknown"
@@ -231,8 +229,9 @@ spec:
         end
 
         return hs
-    submarineraddon.open-cluster-management.io/SubmarinerConfig:
-      health.lua: |
+    - group: submarineraddon.open-cluster-management.io
+      kind: SubmarinerConfig
+      check: |
         hs = {}
 
         if obj.status ~= nil then
@@ -250,8 +249,9 @@ spec:
         hs.status = "Progressing"
         return hs
 
-    hive.openshift.io/ClusterDeployment:
-      health.lua: |
+    - group: hive.openshift.io
+      kind: ClusterDeployment
+      check: |
         hs = {}
 
         if obj.status ~= nil then
@@ -278,8 +278,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    cluster.open-cluster-management.io/ManagedCluster:
-      health.lua: |
+    - group: cluster.open-cluster-management.io
+      kind: ManagedCluster
+      check: |
         hs = {}
 
         if obj.status ~= nil then
@@ -301,8 +302,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    core.automation.ibm.com/Cartridge:
-      health.lua: |
+    - group: core.automation.ibm.com
+      kind: Cartridge
+      check: |
         hs = {}
 
         generation = obj.metadata.generation
@@ -325,8 +327,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    apiconnect.ibm.com/APIConnectCluster:
-      health.lua: |
+    - group: apiconnect.ibm.com
+      kind: APIConnectCluster
+      check: |
         hs = {}
 
         generation = obj.metadata.generation
@@ -358,8 +361,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    datapower.ibm.com/DataPowerService:
-      health.lua: |
+    - group: datapower.ibm.com
+      kind: DataPowerService
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.phase ~= nil then
@@ -376,8 +380,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    icp4a.ibm.com/ICP4ACluster:
-      health.lua: |
+    - group: icp4a.ibm.com
+      kind: ICP4ACluster
+      check: |
         hs = {}
 
         generation = obj.metadata.generation
@@ -421,8 +426,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    integration.ibm.com/PlatformNavigator:
-      health.lua: |
+    - group: integration.ibm.com
+      kind: PlatformNavigator
+      check: |
         hs = {}
 
         generation = obj.metadata.generation
@@ -445,63 +451,9 @@ spec:
 
         hs.status = "Progressing"
         return hs
-    operators.coreos.com/CatalogSource:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.connectionState ~= nil then
-            if obj.status.connectionState.lastObservedState ~= nil then
-              if obj.status.connectionState.lastObservedState == "READY" then
-                hs.status = "Healthy"
-                return hs
-              end
-            end
-          end
-        end
-
-        hs.status = "Progressing"
-        hs.message = "Unknown"
-        return hs
-    operators.coreos.com/InstallPlan:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.phase ~= nil then
-            hs.message = obj.status.phase
-            if obj.status.phase == "Complete" then
-              hs.status = "Healthy"
-            else
-              hs.status = "Progressing"
-            end
-            return hs
-          end
-        end
-
-        hs.status = "Progressing"
-        hs.message = "Unknown"
-        return hs
-    operators.coreos.com/Subscription:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.installedCSV ~= nil then
-            hs.status = "Healthy"
-            hs.message = "CSV Installed"
-            if obj.status.state ~= nil then
-              hs.message = obj.status.state
-            end
-            return hs
-          end
-        end
-
-        hs.status = "Progressing"
-        hs.message = "Unknown"
-        if obj.status.state ~= nil then
-          hs.message = obj.status.state
-        end
-        return hs
-    mq.ibm.com/QueueManager:
-      health.lua: |
+    - group: mq.ibm.com
+      kind: QueueManager
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.phase ~= nil then
@@ -518,8 +470,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    orchestrator.aiops.ibm.com/Installation:
-      health.lua: |
+    - group: orchestrator.aiops.ibm.com
+      kind: Installation
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.phase ~= nil then
@@ -539,8 +492,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    aiops.ibm.com/IAConfig:
-      health.lua: |
+    - group: aiops.ibm.com
+      kind: IAConfig
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.phase ~= nil then
@@ -560,8 +514,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    noi.ibm.com/NOI:
-      health.lua: |
+    - group: noi.ibm.com
+      kind: NOI
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.phase ~= nil then
@@ -580,8 +535,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    cpd.ibm.com/Ibmcpd:
-      health.lua: |
+    - group: cpd.ibm.com
+      kind: Ibmcpd
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.controlPlaneStatus ~= nil then
@@ -601,8 +557,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    db2u.databases.ibm.com/DvService:
-      health.lua: |
+    - group: db2u.databases.ibm.com
+      kind: DvService
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.reconcileStatus ~= nil then
@@ -622,8 +579,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    rstudio.cpd.ibm.com/RStudioAddon:
-      health.lua: |
+    - group: rstudio.cpd.ibm.com
+      kind: RStudioAddon
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.rstudioStatus ~= nil then
@@ -643,8 +601,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    wkc.cpd.ibm.com/WKC:
-      health.lua: |
+    - group: wkc.cpd.ibm.com
+      kind: WKC
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.wkcStatus ~= nil then
@@ -664,8 +623,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    wml.cpd.ibm.com/WmlBase:
-      health.lua: |
+    - group: wml.cpd.ibm.com
+      kind: WmlBase
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.wmlStatus ~= nil then
@@ -685,8 +645,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    wos.cpd.ibm.com/WOService:
-      health.lua: |
+    - group: wos.cpd.ibm.com
+      kind: WOService
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.wosStatus ~= nil then
@@ -706,8 +667,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    ws.cpd.ibm.com/WS:
-      health.lua: |
+    - group: ws.cpd.ibm.com
+      kind: WS
+      check: |
         hs = {}
         if obj.status ~= nil then
           if obj.status.wsStatus ~= nil then
@@ -727,8 +689,9 @@ spec:
         hs.status = "Progressing"
         hs.message = "Unknown"
         return hs
-    isc.ibm.com/CP4SThreatManagement:
-      health.lua: |
+    - group: isc.ibm.com
+      kind: CP4SThreatManagement
+      check: |
         hs = {}
         hs.status = "Progressing"
 
@@ -792,5 +755,9 @@ spec:
       enabled: true
     service:
       type: ""
+  sso:
+    provider: dex
+    dex:
+      openShiftOAuth: true
   tls:
     ca: {}

--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
+++ b/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
@@ -31,13 +31,28 @@ spec:
           object-templates:
             - complianceType: musthave
               objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: openshift-gitops-operator
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: openshift-gitops-operator
+                  namespace: openshift-gitops-operator
+                spec:
+                  upgradeStrategy: Default
+            - complianceType: musthave
+              objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: Subscription
                 metadata:
                   name: openshift-gitops-operator
-                  namespace: openshift-operators
+                  namespace: openshift-gitops-operator
                 spec:
-                  channel: gitops-1.8
+                  channel: gitops-1.10
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,7 @@
       name: openshift-gitops-operator
       namespace: openshift-operators
    spec:
-      channel: gitops-1.8
+      channel: gitops-1.10
       installPlanApproval: Automatic
       name: openshift-gitops-operator
       source: redhat-operators

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -49,13 +49,13 @@ This repository contains governance policies and placement rules for Argo CD and
 
 ### Install the OpenShift GitOps operator
 
-This section contains a simple shortcut, but you can choose to follow the instructions in the [Red Hat OpenShift GitOps Installation page](https://docs.openshift.com/gitops/1.8/installing_gitops/installing-openshift-gitops.html) instead, with special care to **use the `gitops-1.8` subscription channel instead of `latest`** (at least, until issue [#289](https://github.com/IBM/cloudpak-gitops/issues/289) is addressed.)
+This section contains a simple shortcut, but you can choose to follow the instructions in the [Red Hat OpenShift GitOps Installation page](https://docs.openshift.com/gitops/1.10/installing_gitops/installing-openshift-gitops.html) instead, with special care to **use a release at or above `gitops-1.8`**.) These instructions were validated with the OpenShift GitOps 1.10 release.
 
 The shortcut in case you choose to eschew the official instructions:
 
 1. [Log in to the OpenShift CLI](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 
-1. Create the `Subscription` resource for the operator:
+2. Create the `Subscription` resource for the operator:
 
    ```sh
    cat << EOF | oc apply -f -
@@ -66,7 +66,7 @@ The shortcut in case you choose to eschew the official instructions:
       name: openshift-gitops-operator
       namespace: openshift-operators
    spec:
-      channel: gitops-1.8
+      channel: gitops-1.10
       installPlanApproval: Automatic
       name: openshift-gitops-operator
       source: redhat-operators

--- a/tests/descriptors/operators/gitops-operators.yaml
+++ b/tests/descriptors/operators/gitops-operators.yaml
@@ -1,11 +1,24 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-gitops-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  upgradeStrategy: Default
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-gitops-operator
-  namespace: openshift-operators
+  namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.8
+  channel: gitops-1.10
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/tests/postbuild/common.sh
+++ b/tests/postbuild/common.sh
@@ -89,11 +89,8 @@ function check_install_oc() {
         oc_version=$(oc version | grep "Client Version" | cut -d ":" -f 2 | tr -d " ")
         if [ "${oc_version}" == "" ] ||
            [[ ${oc_version} == "3."* ]] ||
-           [[ ${oc_version} == "4.1"* ]] ||
-           [[ ${oc_version} == "4.2"* ]] ||
-           [[ ${oc_version} == "4.3"* ]] ||
-           [[ ${oc_version} == "4.4"* ]]; then
-            log "INFO: OpenShift client is older than 4.5." 
+           [[ ${oc_version} == 4\.[1-9].* ]]; then
+            log "INFO: OpenShift client is older than 4.10." 
             install=1
         fi
     fi


### PR DESCRIPTION
contributes-to: #289

Description of changes:
- Modify ArgoCD configuration to use the new CRD design introduced in OpenShift GitOps 1.9.

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

**With OCP 4.12**

Installing CP4I as an example and validation that the custom health checks still work for its resources:
```
 oc get csv 
NAME                                DISPLAY                    VERSION   REPLACES                           PHASE
openshift-gitops-operator.v1.10.1   Red Hat OpenShift GitOps   1.10.1    openshift-gitops-operator.v1.8.6   Succeeded

argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                    TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                           289-gitops-110
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared       289-gitops-110
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators    289-gitops-110
openshift-gitops/cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-apic      289-gitops-110
openshift-gitops/cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i            289-gitops-110
openshift-gitops/cp4i-mq              https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-mq        289-gitops-110
openshift-gitops/cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-platform  289-gitops-110
openshift-gitops/cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-prereqs   289-gitops-110

argocd app get cp4i-mq 
Name:               openshift-gitops/cp4i-mq
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          cp4i
URL:                https://openshift-gitops-server-openshift-gitops.apps.dngitops289b.cp.fyre.ibm.com/applications/cp4i-mq
Repo:               https://github.com/IBM/cloudpak-gitops.git
Target:             289-gitops-110
Path:               config/cloudpaks/cp4i/install-mq
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to 289-gitops-110 (4711244)
Health Status:      Healthy

GROUP                 KIND          NAMESPACE  NAME                 STATUS  HEALTH   HOOK  MESSAGE
operators.coreos.com  Subscription  cp4i       ibm-mq-ibm-operator  Synced  Healthy        AtLatestKnown
                      ConfigMap     cp4i       mqsc-ini-cases       Synced                 configmap/mqsc-ini-cases unchanged
mq.ibm.com            QueueManager  cp4i       case-queues-1-qmgr   Synced  Healthy        queuemanager.mq.ibm.com/case-queues-1-qmgr created
```