### PR TITLE
feat: Upgrade RHACM to 2.9

### DIFF
--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.8.3
+appVersion: 2.9.1

--- a/config/rhacm/seeds/templates/0000-namespace-multi-cluster-engine.yaml
+++ b/config/rhacm/seeds/templates/0000-namespace-multi-cluster-engine.yaml
@@ -1,5 +1,3 @@
-{{- $hypershift := .Values.spec.components.hypershift_preview }}
-{{- if eq ( default false $hypershift ) true  }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -7,4 +5,3 @@ metadata:
   labels:
     argocd.argoproj.io/managed-by: {{.Values.metadata.argocd_namespace}}
   name: multicluster-engine
-{{- end }}

--- a/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
+++ b/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
@@ -8,7 +8,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
 spec:
-  channel: release-2.8
+  channel: release-2.9
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators

--- a/config/rhacm/seeds/templates/0200-gitops-managed-cluster-set.yaml
+++ b/config/rhacm/seeds/templates/0200-gitops-managed-cluster-set.yaml
@@ -1,4 +1,4 @@
-# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/applications/managing-applications#gitops-config
+# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/applications/managing-applications#gitops-config
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet

--- a/config/rhacm/seeds/templates/0301-managed-cluster-set-bindings.yaml
+++ b/config/rhacm/seeds/templates/0301-managed-cluster-set-bindings.yaml
@@ -1,6 +1,6 @@
 # Creates a ManagedClusterSetBinding to the openshift-gitops project
 ---
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   annotations:

--- a/config/rhacm/seeds/templates/9000-post-multi-cluster-engine.yaml
+++ b/config/rhacm/seeds/templates/9000-post-multi-cluster-engine.yaml
@@ -1,4 +1,4 @@
-# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html-single/clusters/index#hosting-service-cluster-configure-aws
+# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html-single/clusters/index#hosting-service-cluster-configure-aws
 ---
 apiVersion: batch/v1
 kind: Job

--- a/docs/install.md
+++ b/docs/install.md
@@ -66,9 +66,9 @@
 
    Ideally, the client's minor version should be at most one iteration behind the server version. Most commands here are pretty basic and will work with more significant differences, but keep that in mind if you see errors about unrecognized commands and parameters.
 
-   If you do not have the CLI installed, follow [these instructions](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html).
+   If you do not have the CLI installed, follow [these instructions](https://docs.openshift.com/container-platform/4.14/cli_reference/openshift_cli/getting-started-cli.html).
 
-1. [Login to the OpenShift CLI](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
+1. [Login to the OpenShift CLI](https://docs.openshift.com/container-platform/4.14/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 
 1. Create the `Subscription` resource for the operator:
 

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -39,7 +39,7 @@ This repository contains governance policies and placement rules for Argo CD and
 
 - Adequate worker node capacity in the cluster for RHACM to be installed.
 
-  Refer to the [RHACM documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/install/installing#sizing-your-cluster) to determine the required capacity for the cluster.
+  Refer to the [RHACM documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/install/installing#sizing-your-cluster) to determine the required capacity for the cluster.
 
 - [An entitlement key to the IBM Entitled Registry](#obtain-an-entitlement-key). This key is required in the RHACM cluster to be copied to the managed clusters when a cluster matches a policy to install a Cloud Pak.
 
@@ -51,36 +51,49 @@ This repository contains governance policies and placement rules for Argo CD and
 
 This section contains a simple shortcut, but you can choose to follow the instructions in the [Red Hat OpenShift GitOps Installation page](https://docs.openshift.com/gitops/1.10/installing_gitops/installing-openshift-gitops.html) instead, with special care to **use a release at or above `gitops-1.8`**.) These instructions were validated with the OpenShift GitOps 1.10 release.
 
-The shortcut in case you choose to eschew the official instructions:
+The shortcut in case you choose to skip the official instructions:
 
-1. [Log in to the OpenShift CLI](https://docs.openshift.com/container-platform/4.7/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
+1. [Log in to the OpenShift CLI](https://docs.openshift.com/container-platform/4.14/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands)
 
 2. Create the `Subscription` resource for the operator:
 
    ```sh
    cat << EOF | oc apply -f -
    ---
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: openshift-gitops-operator
+   ---
+   apiVersion: operators.coreos.com/v1
+   kind: OperatorGroup
+   metadata:
+     name: openshift-gitops-operator
+     namespace: openshift-gitops-operator
+   spec:
+     upgradeStrategy: Default
+   ---
    apiVersion: operators.coreos.com/v1alpha1
    kind: Subscription
    metadata:
-      name: openshift-gitops-operator
-      namespace: openshift-operators
+     name: openshift-gitops-operator
+     namespace: openshift-gitops-operator
    spec:
-      channel: gitops-1.10
-      installPlanApproval: Automatic
-      name: openshift-gitops-operator
-      source: redhat-operators
-      sourceNamespace: openshift-marketplace
+     channel: gitops-1.10
+     installPlanApproval: Automatic
+     name: openshift-gitops-operator
+     source: redhat-operators
+     sourceNamespace: openshift-marketplace
    EOF
    ```
 
    Wait until the ArgoCD instance appears as ready in the `openshift-gitops` namespace.
 
    ```sh
-    oc wait ArgoCD openshift-gitops \
-        -n openshift-gitops \
-        --for=jsonpath='{.status.phase}'=Available \
-        --timeout=600s
+   oc wait ArgoCD openshift-gitops \
+       -n openshift-gitops \
+       --for=jsonpath='{.status.phase}'=Available \
+       --timeout=600s
    ```
 
 ### Configure the ArgoCD CLI
@@ -230,7 +243,7 @@ Labels:
 - `gitops-branch` + `cp4i`: Placement for Cloud Pak for Integration.
 - `gitops-branch` + `cp4s`: Placement for Cloud Pak for Security.
 - `gitops-branch` + `cp4aiops`: Placement for Cloud Pak for AIOps.
-- `gitops-remote` + `true`: Assign cluster to the `gitops-cluster` cluster-set, registering it to the [GitOps Cluster](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/applications/managing-applications#gitops-config).
+- `gitops-remote` + `true`: Assign cluster to the `gitops-cluster` cluster-set, registering it to the [GitOps Cluster](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/applications/managing-applications#gitops-config).
 
 Values for each label:
 

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -17,7 +17,6 @@ ignore: |
   config/rhacm/cloudpaks/templates/placement-cloudpaks.yaml
   config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
   config/rhacm/cloudpaks/templates/placement-gitops-policy.yaml
-  config/rhacm/seeds/templates/0000-namespace-multi-cluster-engine.yaml
   config/rhacm/seeds/templates/0020-rhacm-hypershift-preview-roles.yaml
 
 rules:


### PR DESCRIPTION
closes: #297

Description of changes:
- Upgrade RHACM subscription channel to 2.9
- Update links to RHACM and OCP documentation
- Update installation instructions
- Fix conditional creation of `multicluster-engine` namespace, as it should not be conditional
- Update API version for deprecated API groups

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                                  CLUSTER                         NAMESPACE                PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                  TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops         argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                         297-rhacm-29
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks            default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared     297-rhacm-29
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks            default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators  297-rhacm-29
openshift-gitops/rhacm-app            https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-rhacm                   297-rhacm-29
openshift-gitops/rhacm-cloudpaks      https://kubernetes.default.svc  openshift-gitops         rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/cloudpaks                297-rhacm-29
openshift-gitops/rhacm-seeds          https://kubernetes.default.svc  open-cluster-management  rhacm-control-plane   Synced  Healthy  Auto        <none>      https://github.com/IBM/cloudpak-gitops  config/rhacm/seeds                    297-rhacm-29
```

I also validated the installation by creating an AWS cluster:
<img width="1724" alt="image" src="https://github.com/IBM/cloudpak-gitops/assets/3278623/c38f77ca-5332-44b7-9acd-6718237974d2">
