### PR TITLE
feat: Support Red Hat Cert Manager

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
@@ -157,9 +157,10 @@ spec:
               oc get configmap "${config_map_name}" \
                   --namespace "${ARGOCD_NAMESPACE}" > /dev/null 2>&1 \
               && oc patch configmap "${config_map_name}" \
-                  --patch "{\"data\":{\"serviceaccount.argocd_application_controller\":\"{{.Values.serviceaccount.argocd_application_controller}}\", \"shared_configuration.sc_deployment_platform\":\"${cp4a_platform}\", \"storageclass.gold\":\"${storage_class_gold}\", \"storageclass.silver\":\"${storage_class_silver}\", \"storageclass.bronze\":\"${storage_class_bronze}\", \"storageclass.block\":\"${storage_class_rwo}\" }}" \
+                  --patch "{\"data\":{\"red_hat_cert_manager\":\"{{.Values.red_hat_cert_manager}}\", \"serviceaccount.argocd_application_controller\":\"{{.Values.serviceaccount.argocd_application_controller}}\", \"shared_configuration.sc_deployment_platform\":\"${cp4a_platform}\", \"storageclass.gold\":\"${storage_class_gold}\", \"storageclass.silver\":\"${storage_class_silver}\", \"storageclass.bronze\":\"${storage_class_bronze}\", \"storageclass.block\":\"${storage_class_rwo}\" }}" \
                   --namespace "${ARGOCD_NAMESPACE}" \
               || oc create configmap "${config_map_name}" \
+                  --from-literal=red_hat_cert_manager="${red_hat_cert_manager}" \
                   --from-literal=serviceaccount.argocd_application_controller="{{.Values.serviceaccount.argocd_application_controller}}" \
                   --from-literal=shared_configuration.sc_deployment_platform="${cp4a_platform}" \
                   --from-literal=storageclass.gold="${storage_class_gold}" \

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -37,14 +37,16 @@ spec:
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4s}}"
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
-        - name: storageclass.rwo.override
-          value: "{{.Values.storageclass.rwo.override}}"
-        - name: storageclass.rwx.override
-          value: "{{.Values.storageclass.rwx.override}}"
+        - name: red_hat_cert_manager
+          value: "{{.Values.red_hat_cert_manager | toString}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller
           value: {{.Values.serviceaccount.argocd_application_controller}}
+        - name: storageclass.rwo.override
+          value: "{{.Values.storageclass.rwo.override}}"
+        - name: storageclass.rwx.override
+          value: "{{.Values.storageclass.rwx.override}}"
         - name: targetRevision
           value: ${ARGOCD_APP_SOURCE_TARGET_REVISION}
     path: config/argocd-cloudpaks/cp-shared

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
@@ -25,6 +25,8 @@ spec:
       parameters:
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
+        - name: red_hat_cert_manager
+          value: "{{.Values.red_hat_cert_manager | toString}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -14,6 +14,7 @@ dedicated_cs:
     cp4i: cp4i
     cp4s: cp4s
 online_catalog_source_priority: -1
+red_hat_cert_manager: false
 storageclass:
   rwo:
     override:

--- a/config/argocd-cloudpaks/cp4a/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4a/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "0.5.2"
+appVersion: 0.6.2

--- a/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-prereq-config.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-prereq-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cp4a-adjust-ocp-platform
+  name: cp4a-adjust-prereq-config
   annotations:
     argocd.argoproj.io/hook: PreSync
   namespace: openshift-gitops
@@ -13,32 +13,29 @@ spec:
         - name: config
           image: quay.io/openshift/origin-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "250m"
-            limits:
-              memory: "128Mi"
-              cpu: "300m"
           env:
             - name: ARGOCD_APP_NAME
               value: cp4a-app
             - name: ARGOCD_NAMESPACE
-              value: openshift-gitops
+              value: "{{.Values.metadata.argocd_namespace}}"
           command:
             - /bin/sh
             - -c
             - |
               set -eo pipefail
               set -x
+
+              red_hat_cert_manager=$(oc get configmap argocd-cp4a-config \
+                  --namespace "${ARGOCD_NAMESPACE}" -o jsonpath='{.data.red_hat_cert_manager}')
+
               # https://www.ibm.com/docs/en/cloud-paks/cp-biz-automation/21.0.x?topic=deployment-installing-capabilities-in-operator-hub
               platform=$(oc get configmap argocd-cp4a-config \
                   --namespace "${ARGOCD_NAMESPACE}" -o jsonpath='{.data.shared_configuration\.sc_deployment_platform}')
 
               echo "INFO: Install Argo CLI."
               # Install it from cluster, not from Internet, so airgap scenarios still work
-              argo_route=openshift-gitops-server
-              argo_secret=openshift-gitops-cluster
+              argo_route="${ARGOCD_NAMESPACE}-server"
+              argo_secret="${ARGOCD_NAMESPACE}-cluster"
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"
@@ -50,6 +47,7 @@ spec:
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               && "${argo_cmd}" app set "${ARGOCD_APP_NAME}" \
+                  --helm-set-string red_hat_cert_manager="${red_hat_cert_manager}" \
                   --helm-set-string spec.shared_configuration.sc_deployment_platform="${platform}" \
               && echo "INFO: ${ARGOCD_APP_NAME} successfully updated OCP platform." \
               || result=1

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-app.yaml
@@ -28,6 +28,8 @@ spec:
           value: ${ARGOCD_APP_NAMESPACE}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
+        - name: red_hat_cert_manager
+          value: "{{.Values.red_hat_cert_manager | toString}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp4a/templates/cp4a-operator-app.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/cp4a-operator-app.yaml
@@ -32,6 +32,8 @@ spec:
           value: ${ARGOCD_APP_NAMESPACE}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
+        - name: red_hat_cert_manager
+          value: "{{.Values.red_hat_cert_manager | toString}}"
         - name: repoURL
           value: ${ARGOCD_APP_SOURCE_REPO_URL}
         - name: serviceaccount.argocd_application_controller

--- a/config/argocd-cloudpaks/cp4a/values.yaml
+++ b/config/argocd-cloudpaks/cp4a/values.yaml
@@ -6,6 +6,7 @@ serviceaccount:
 metadata:
   argocd_app_namespace: cp4a
   argocd_namespace: openshift-gitops
+red_hat_cert_manager: false
 spec:
   shared_configuration:
     sc_deployment_platform: ROKS

--- a/config/cloudpaks/cp-shared/operators/Chart.yaml
+++ b/config/cloudpaks/cp-shared/operators/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/config/cloudpaks/cp-shared/operators/templates/0000-rh-cert-manager-namespace.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0000-rh-cert-manager-namespace.yaml
@@ -1,0 +1,10 @@
+{{- $red_hat_cert_manager := .Values.red_hat_cert_manager | toString }}
+{{- if eq ( default "false" $red_hat_cert_manager ) "true" }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+spec: {}
+status: {}
+{{- end }}

--- a/config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
@@ -1,0 +1,15 @@
+{{- $red_hat_cert_manager := .Values.red_hat_cert_manager | toString }}
+{{- if eq ( default "false" $red_hat_cert_manager ) "true" }}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+    - cert-manager-operator
+  upgradeStrategy: Default
+{{- end }}

--- a/config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
@@ -1,0 +1,17 @@
+{{- $red_hat_cert_manager := .Values.red_hat_cert_manager | toString }}
+{{- if eq ( default "false" $red_hat_cert_manager ) "true" }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+{{- end }}

--- a/config/cloudpaks/cp-shared/operators/values.yaml
+++ b/config/cloudpaks/cp-shared/operators/values.yaml
@@ -1,4 +1,5 @@
 ---
+red_hat_cert_manager: false
 metadata:
   argocd_namespace: openshift-gitops
 serviceaccount:

--- a/config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
@@ -1,8 +1,10 @@
+{{- $red_hat_cert_manager := .Values.red_hat_cert_manager | toString }}
+{{- if eq ( default "false" $red_hat_cert_manager ) "false" }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-cluster-scoper-operators
+  name: sync-cluster-scoped-operators
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-wave: "50"
@@ -17,7 +19,7 @@ spec:
           env:
             - name: ARGOCD_NAMESPACE
               value: "openshift-gitops"
-            - name: IBM_CERT_MANAGER
+            - name: IBM_CERT_MANAGER_NAMESPACE
               value: {{.Values.metadata.cert_manager_namespace}}
             - name: IBM_CERT_MANAGER_CHANNEL
               value: {{.Values.metadata.cert_manager_channel}}
@@ -41,13 +43,13 @@ spec:
               kind: Namespace
               apiVersion: v1
               metadata:
-                  name: ${IBM_CERT_MANAGER:?}
+                  name: ${IBM_CERT_MANAGER_NAMESPACE:?}
               ---
               apiVersion: operators.coreos.com/v1
               kind: OperatorGroup
               metadata:
                 name: ibm-cert-manager
-                namespace: ${IBM_CERT_MANAGER:?}
+                namespace: ${IBM_CERT_MANAGER_NAMESPACE:?}
               spec:
                 upgradeStrategy: Default
               ---
@@ -55,7 +57,7 @@ spec:
               kind: Subscription
               metadata:
                 name: ibm-cert-manager-operator
-                namespace: ${IBM_CERT_MANAGER:?}
+                namespace: ${IBM_CERT_MANAGER_NAMESPACE:?}
               spec:
                 channel: ${IBM_CERT_MANAGER_CHANNEL:?}
                 installPlanApproval: Automatic
@@ -63,8 +65,8 @@ spec:
                 source: ibm-operator-catalog
                 sourceNamespace: openshift-marketplace
               EOF
-                      oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER:?} --for=CatalogSourcesUnhealthy=False \
-                      && oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER:?} --for=jsonpath='state'="AtLatestKnown" \
+                      oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER_NAMESPACE:?} --for=CatalogSourcesUnhealthy=False \
+                      && oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER_NAMESPACE:?} --for=jsonpath='state'="AtLatestKnown" \
                       && echo "INFO: Successfully installed IBM Cert Manager." \
                       || result=1
                   else
@@ -86,3 +88,4 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
   backoffLimit: 2
+{{- end}}

--- a/config/cloudpaks/cp4a/operators/values.yaml
+++ b/config/cloudpaks/cp4a/operators/values.yaml
@@ -2,7 +2,7 @@
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   cert_manager_namespace: ibm-cert-manager
-  cert_manager_channel: v4.1
+  cert_manager_channel: v4.2
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller
 storageclass:

--- a/docs/install.md
+++ b/docs/install.md
@@ -323,16 +323,23 @@ After completing the list of activities listed in the previous sections, you can
    ```sh
    cp_namespace=ibm-cloudpaks
 
+   # Switch to true if you want to use Red Hat Cert Manager instead of 
+   # IBM Cert Manager.
+   #
+   # ** This is only supported for CP4BA and CP4D **
+   #
+   red_hat_cert_manager=false
+
    # If you want to override the default target namespace for 
    # one or more Cloud Paks, you need to adjust the values below
    # to indicate the desired target namespace.
-   # dedicated_cs_enabled=true
+   #
+   # This setting only affects CP4I and CP4S
+   #
    dedicated_cs_enabled=false
-   cp4a_namespace=cp4a
-   cp4d_namespace=cp4d
+
    cp4i_namespace=cp4i
    cp4s_namespace=cp4s
-   cp4aiops_namespace=cp4aiops
 
    argocd app create cp-shared-app \
          --project default \
@@ -342,20 +349,21 @@ After completing the list of activities listed in the previous sections, you can
          --path config/argocd-cloudpaks/cp-shared \
          --helm-set-string argocd_app_namespace="${cp_namespace}" \
          --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
+         --helm-set-string red_hat_cert_manager="${red_hat_cert_manager:-false}" \
          --helm-set-string dedicated_cs.enabled="${dedicated_cs_enabled:-false}" \
-         --helm-set-string dedicated_cs.namespace_mapping.cp4i="${cp4i_namespace}" \
-         --helm-set-string dedicated_cs.namespace_mapping.cp4s="${cp4s_namespace}" \
-         --sync-policy automated \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4i="${cp4i_namespace:-cp4i}" \
+         --helm-set-string dedicated_cs.namespace_mapping.cp4s="${cp4s_namespace:-cp4s}" \
+         --helm-set-string targetRevision="${gitops_branch:?}" \
          --revision ${gitops_branch:?} \
+         --sync-policy automated \
          --upsert
    ```
 
 1. Add the respective Cloud Pak application (this step assumes you still have shell variables assigned from previous steps) :
 
    ```sh
-   # appname=<< choose a value from the "Application Name" column in the 
-   # table of Cloud Paks above, such as cp4a-app, cp4i-app, 
-   # cp4aiops-app, cp4d-app, etc >>
+   # Choose a value from the "Application Name" column in the 
+   # table of Cloud Paks above, such as cp4a, cp4i, or cp4d
    cp=cp4i
 
    # Note that if you want to use a target namespace that is not the
@@ -366,7 +374,7 @@ After completing the list of activities listed in the previous sections, you can
    app_name=${cp}-app
    # app_path=<< choose the respective value from the "path name." 
    # column in the table of Cloud Paks above, such as 
-   # config/argocd-cloudpaks/cp4i/cp4a, config/argocd-cloudpaks/cp4i, 
+   # config/argocd-cloudpaks/cp4a, config/argocd-cloudpaks/cp4i, 
    # etc
    app_path=config/argocd-cloudpaks/${cp}
 
@@ -374,7 +382,7 @@ After completing the list of activities listed in the previous sections, you can
          --project default \
          --dest-namespace openshift-gitops \
          --dest-server https://kubernetes.default.svc \
-         --helm-set-string metadata.argocd_app_namespace="${cp_namespace}" \
+         --helm-set-string metadata.argocd_app_namespace="${cp_namespace:?}" \
          --helm-set-string repoURL=${gitops_url:?} \
          --helm-set-string targetRevision="${gitops_branch}" \
          --path "${app_path}" \

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -6,7 +6,11 @@ ignore: |
   config/argocd-cloudpaks/cp4i/templates/0400-cp4i-client-app.yaml
   config/argocd-cloudpaks/cp4aiops/templates/000-aimgr-namespace.yaml
   config/argocd-cloudpaks/cp4aiops/templates/130-cp4aiops-ia-app.yaml
+  config/cloudpaks/cp-shared/operators/templates/0000-rh-cert-manager-namespace.yaml
+  config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
+  config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
   config/cloudpaks/cp4a/operators/templates/0000-cp4ba-namespace.yaml
+  config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
   config/cloudpaks/cp4a/operators/templates/0100-operator-group.yaml
   config/cloudpaks/cp4i/install-prereqs/templates/0000-namespace.yaml
   config/cloudpaks/cp4i/install-prereqs/templates/0100-operator-group.yaml


### PR DESCRIPTION
closes: #303

Description of changes:
- Adds new red_hat_cert_manager parameter to `cp-shared` and `cp4a-app` applications and sub-applications.
- Adds conditional processing for adding either Red Hat Cert Manager or IBM Cert Manager depending on the value of the flag.

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
argocd app get cp4a-app --show-params
Name:               openshift-gitops/cp4a-app
Project:            default
Server:             https://kubernetes.default.svc
Namespace:          cp4a
URL:                https://openshift-gitops-server-openshift-gitops.apps.dncp4bacert.cp.fyre.ibm.com/applications/cp4a-app
Repo:               https://github.com/IBM/cloudpak-gitops
Target:             303-rh-cert
Path:               config/argocd-cloudpaks/cp4a
SyncWindow:         Sync Allowed
Sync Policy:        Automated (Prune)
Sync Status:        Synced to 303-rh-cert (1aa3778)
Health Status:      Healthy


oc get sub -A | grep cert
cert-manager-operator       openshift-cert-manager-operator                                                 openshift-cert-manager-operator   redhat-operators       stable-v1


NAME                                              VALUE
argocd_app_name                                   ${ARGOCD_APP_NAME}
argocd_app_namespace                              ${ARGOCD_APP_NAMESPACE}
metadata.argocd_app_namespace                     cp4a
red_hat_cert_manager                              true  <<<<<
repoURL                                           ${ARGOCD_APP_SOURCE_REPO_URL}
serviceaccount.argocd_application_controller      openshift-gitops-argocd-application-controller
spec.shared_configuration.sc_deployment_platform  OCP
storageclass.block                                rook-ceph-block
storageclass.bronze                               rook-cephfs
storageclass.gold                                 rook-cephfs
storageclass.silver                               rook-cephfs
targetRevision                                    ${ARGOCD_APP_SOURCE_TARGET_REVISION}

GROUP        KIND         NAMESPACE         NAME                       STATUS     HEALTH   HOOK     MESSAGE
batch        Job          openshift-gitops  cp4a-storage-classes       Succeeded           PreSync  job.batch/cp4a-storage-classes created
batch        Job          openshift-gitops  cp4a-adjust-prereq-config  Succeeded           PreSync  job.batch/cp4a-adjust-prereq-config created
argoproj.io  Application  openshift-gitops  cp4a-operators             Synced     Healthy           application.argoproj.io/cp4a-operators configured
argoproj.io  Application  openshift-gitops  cp4a-app                   Synced                       application.argoproj.io/cp4a-app configured
argoproj.io  Application  openshift-gitops  cp4a-resources             Synced     Healthy           application.argoproj.io/cp4a-resources configured

argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                         HEAD
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp-shared     303-rh-cert
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp-shared/operators  303-rh-cert
openshift-gitops/cp4a-app             https://kubernetes.default.svc  cp4a              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/argocd-cloudpaks/cp4a          303-rh-cert
openshift-gitops/cp4a-operators       https://kubernetes.default.svc  cp4a              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4a/operators       303-rh-cert
openshift-gitops/cp4a-resources       https://kubernetes.default.svc  cp4a              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops      config/cloudpaks/cp4a/resources       303-rh-cert
```