### PR TITLE
fix: Patch Zen database for CP4D

### DIFF
--- a/config/cloudpaks/cp4d/Chart.yaml
+++ b/config/cloudpaks/cp4d/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4d/templates/0100-config-placeholder.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-config-placeholder.yaml
@@ -9,4 +9,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitops-cp4d-dummy
-  namespace: {{.Values.metadata.operators_namespace}}
+  namespace: {{.Values.metadata.operands_namespace}}
+data:
+  components: {{.Values.components}}
+  stg_class_block: {{.Values.storageclass.rwo}}
+  stg_class_file: {{.Values.storageclass.rwx}}
+  version: {{.Values.version}}

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-zen-workaround.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-zen-workaround.yaml
@@ -1,0 +1,72 @@
+---
+# https://www.ibm.com/support/pages/node/7087504
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "101"
+  name: sync-cp4d-install-zen-workaround
+  namespace: {{.Values.metadata.argocd_namespace}}
+spec:
+  template:
+    spec:
+      containers:
+        - name: patch-zen-database
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          env:
+            - name: COMPONENTS
+              value: {{.Values.components}}
+            - name: PROJECT_CPD_INST_OPERANDS
+              value: {{.Values.metadata.operands_namespace}}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -eo pipefail
+              set -x
+
+              patch_needed=0
+              if [[ ${COMPONENTS:?} =~ cognos_analytics ]] \
+                  || [[ ${COMPONENTS} =~ db2 ]] \
+                  || [[ ${COMPONENTS} =~ bigsql ]] \
+                  || [[ ${COMPONENTS} =~ wkc ]] \
+                  || [[ ${COMPONENTS} =~ wml_accelerator ]]; then
+                  patch_needed=1
+              fi
+
+              if [ ${patch_needed} -eq 0 ]; then
+                  exit 0
+              fi
+
+              result=1
+
+              while [ ${result} -eq 1 ] && [ ${SECONDS} -lt 7200 ]
+              do
+                  oc get deployment zen-databases \
+                      -n ${PROJECT_CPD_INST_OPERANDS} \
+                  && result=0 \
+                  || {
+                      echo "INFO: Waiting on Zen database deployment to patch it"
+                      sleep 60
+                  }
+              done
+
+              if [ ${result} -eq 0 ]; then
+                  oc patch deployment zen-databases \
+                      -n ${PROJECT_CPD_INST_OPERANDS} \
+                      --type='json' \
+                      -p='[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "npm_config_cache", "value": "/tmp"}}]' \
+                  || {
+                      echo "ERROR: CP4D installation failed."
+                      result=1
+                  }
+              fi
+
+              exit ${result}
+
+      restartPolicy: Never
+      serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
+
+  backoffLimit: 2


### PR DESCRIPTION
closes: #304 

Description of changes:
- Applies the patch of the technote listed in the issue: https://www.ibm.com/support/pages/node/7087504

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

Logs of the job execution:

```
+ result=1
+ '[' 1 -eq 1 ']'
+ '[' 0 -lt 7200 ']'
+ oc get deployment zen-databases -n cp4d-operands
W1208 13:37:21.615072       7 loader.go:222] Config not found: /opt/ansible/.kubeconfig
NAME            READY   UP-TO-DATE   AVAILABLE   AGE
zen-databases   2/2     2            2           12h
+ result=0
+ '[' 0 -eq 1 ']'
+ '[' 0 -eq 0 ']'
+ oc patch deployment zen-databases -n cp4d-operands --type=json '-p=[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "npm_config_cache", "value": "/tmp"}}]'
W1208 13:37:21.773219      26 loader.go:222] Config not found: /opt/ansible/.kubeconfig
Warning: spec.template.spec.containers[0].env[3].name: duplicate name "npm_config_cache"
deployment.apps/zen-databases patched
+ exit 0
```
