### PR TITLE
fix: Fix sync condition to cleanup IBM Cert Mgr

### DIFF
--- a/config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
@@ -1,5 +1,3 @@
-{{- $red_hat_cert_manager := .Values.red_hat_cert_manager | toString }}
-{{- if eq ( default "false" $red_hat_cert_manager ) "false" }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -19,6 +17,8 @@ spec:
           env:
             - name: ARGOCD_NAMESPACE
               value: "openshift-gitops"
+            - name: RED_HAT_CERT_MANAGER_ENABLED
+              value: "{{.Values.red_hat_cert_manager}}"
             - name: IBM_CERT_MANAGER_NAMESPACE
               value: {{.Values.metadata.cert_manager_namespace}}
             - name: IBM_CERT_MANAGER_CHANNEL
@@ -31,6 +31,15 @@ spec:
               set -x
 
               result=0
+              if [ "${RED_HAT_CERT_MANAGER_ENABLED}" == "true" ]; then
+                  oc delete Subscription.operators.coreos.com ibm-cert-manager-operator \
+                      -n "${IBM_CERT_MANAGER_NAMESPACE:?}" \
+                      --ignore-not-found=true
+                  oc delete Namespace "${IBM_CERT_MANAGER_NAMESPACE:?}" \
+                      --ignore-not-found=true
+                  exit "${result}"
+              fi
+
               ibm_cert_manager_count=$(oc get Subscription.operators.coreos.com \
                     -l operators.coreos.com/ibm-cert-manager-operator.ibm-cert-manager \
                     -A \
@@ -88,4 +97,3 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{.Values.serviceaccount.argocd_application_controller}}
   backoffLimit: 2
-{{- end}}

--- a/config/cloudpaks/cp4a/operators/templates/0100-config-placeholder.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/0100-config-placeholder.yaml
@@ -1,0 +1,15 @@
+# This is not actually used by CP4BA.
+#
+# ArgoCD cannot recognize changes to the content
+# of sync hooks (such as an env variable for a container)
+# so this config map contains the env variables
+# referenced in sync hooks to ensure ArgoCD realizes
+# a relevant config value has changed.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitops-cp4a-dummy
+  namespace: {{.Values.metadata.argocd_app_namespace}}
+data:
+  red_hat_cert_manager: "{{.Values.red_hat_cert_manager}}"

--- a/config/cloudpaks/cp4a/operators/values.yaml
+++ b/config/cloudpaks/cp4a/operators/values.yaml
@@ -3,6 +3,7 @@ metadata:
   argocd_app_namespace: ibm-cloudpaks
   cert_manager_namespace: ibm-cert-manager
   cert_manager_channel: v4.2
+red_hat_cert_manager: false
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller
 storageclass:

--- a/tests/prebuild/yamllint-config.yaml
+++ b/tests/prebuild/yamllint-config.yaml
@@ -10,7 +10,6 @@ ignore: |
   config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
   config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
   config/cloudpaks/cp4a/operators/templates/0000-cp4ba-namespace.yaml
-  config/cloudpaks/cp4a/operators/templates/0050-sync-cluster-scoped-operators.yaml
   config/cloudpaks/cp4a/operators/templates/0100-operator-group.yaml
   config/cloudpaks/cp4i/install-prereqs/templates/0000-namespace.yaml
   config/cloudpaks/cp4i/install-prereqs/templates/0100-operator-group.yaml


### PR DESCRIPTION
contributes-to: #303

Description of changes:
- Deletes eventual IBM Cert Manager if Red Hat Cert Manager is enabled

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.


(After manually setting the `red_hat_cert_manager` property in `cp-shared-app` and `cp4a-app` and synchronizing everything.) 
```
argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                  TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                         303-cp4ba-rh
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared     303-cp4ba-rh
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators  303-cp4ba-rh
openshift-gitops/cp4a-app             https://kubernetes.default.svc  cp4a              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4a          303-cp4ba-rh
openshift-gitops/cp4a-operators       https://kubernetes.default.svc  cp4a              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/operators       303-cp4ba-rh
openshift-gitops/cp4a-resources       https://kubernetes.default.svc  cp4a              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4a/resources       303-cp4ba-rh
```