### PR TITLE
fix: Update GitOps operator to latest

### DIFF
--- a/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
+++ b/config/rhacm/seeds/templates/0200-policy-openshift-gitops.yaml
@@ -52,7 +52,7 @@ spec:
                   name: openshift-gitops-operator
                   namespace: openshift-gitops-operator
                 spec:
-                  channel: gitops-1.10
+                  channel: latest
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,7 @@
       name: openshift-gitops-operator
       namespace: openshift-operators
    spec:
-      channel: gitops-1.10
+      channel: latest
       installPlanApproval: Automatic
       name: openshift-gitops-operator
       source: redhat-operators

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -49,7 +49,7 @@ This repository contains governance policies and placement rules for Argo CD and
 
 ### Install the OpenShift GitOps operator
 
-This section contains a simple shortcut, but you can choose to follow the instructions in the [Red Hat OpenShift GitOps Installation page](https://docs.openshift.com/gitops/1.10/installing_gitops/installing-openshift-gitops.html) instead, with special care to **use a release at or above `gitops-1.8`**.) These instructions were validated with the OpenShift GitOps 1.10 release.
+This section contains a simple shortcut, but you can choose to follow the instructions in the [Red Hat OpenShift GitOps Installation page](https://docs.openshift.com/gitops/1.11/installing_gitops/installing-openshift-gitops.html) instead, with special care to **use a release at or above `gitops-1.8`**.) These instructions are always validated with the latest OpenShift GitOps release.
 
 The shortcut in case you choose to skip the official instructions:
 
@@ -79,7 +79,7 @@ The shortcut in case you choose to skip the official instructions:
      name: openshift-gitops-operator
      namespace: openshift-gitops-operator
    spec:
-     channel: gitops-1.10
+     channel: latest
      installPlanApproval: Automatic
      name: openshift-gitops-operator
      source: redhat-operators

--- a/tests/descriptors/operators/gitops-operators.yaml
+++ b/tests/descriptors/operators/gitops-operators.yaml
@@ -18,7 +18,7 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: gitops-1.10
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

closes: #311

Description of changes:
- Uses `latest` release of GitOps instead of a fixed release.

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

