### PR TITLE
fix: Parameterize OperatorGroup for cert manager

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.6.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-app.yaml
@@ -35,6 +35,16 @@ spec:
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4i}}"
         - name: dedicated_cs.namespace_mapping.cp4s
           value: "{{.Values.dedicated_cs.namespace_mapping.cp4s}}"
+        - name: metadata.ibm_cert_manager_channel
+          value: {{.Values.metadata.ibm_cert_manager_channel}}
+        - name: metadata.ibm_cert_manager_namespace
+          value: {{.Values.metadata.ibm_cert_manager_namespace}}
+        - name: metadata.ibm_cert_manager_operator_group
+          value: {{.Values.metadata.ibm_cert_manager_operator_group}}
+        - name: metadata.redhat_cert_manager_namespace
+          value: {{.Values.metadata.redhat_cert_manager_namespace}}
+        - name: metadata.redhat_cert_manager_operator_group
+          value: {{.Values.metadata.redhat_cert_manager_operator_group}}
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
         - name: red_hat_cert_manager

--- a/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0100-cp-shared-operators-app.yaml
@@ -23,6 +23,16 @@ spec:
   source:
     helm:
       parameters:
+        - name: metadata.ibm_cert_manager_channel
+          value: {{.Values.metadata.ibm_cert_manager_channel}}
+        - name: metadata.ibm_cert_manager_namespace
+          value: {{.Values.metadata.ibm_cert_manager_namespace}}
+        - name: metadata.ibm_cert_manager_operator_group
+          value: {{.Values.metadata.ibm_cert_manager_operator_group}}
+        - name: metadata.redhat_cert_manager_namespace
+          value: {{.Values.metadata.redhat_cert_manager_namespace}}
+        - name: metadata.redhat_cert_manager_operator_group
+          value: {{.Values.metadata.redhat_cert_manager_operator_group}}
         - name: online_catalog_source_priority
           value: "{{.Values.online_catalog_source_priority}}"
         - name: red_hat_cert_manager

--- a/config/argocd-cloudpaks/cp-shared/values.yaml
+++ b/config/argocd-cloudpaks/cp-shared/values.yaml
@@ -7,6 +7,11 @@ serviceaccount:
 metadata:
   argocd_app_namespace: ibm-cloudpaks
   argocd_namespace: openshift-gitops
+  ibm_cert_manager_channel: v4.2
+  ibm_cert_manager_namespace: ibm-cert-manager
+  ibm_cert_manager_operator_group: ibm-cert-manager-operator-group
+  redhat_cert_manager_namespace: cert-manager-operator
+  redhat_cert_manager_operator_group: cert-manager-operator-group
 dedicated_cs:
   control_namespace: cs-control
   enabled: false

--- a/config/cloudpaks/cp-shared/operators/Chart.yaml
+++ b/config/cloudpaks/cp-shared/operators/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.2.0"
+appVersion: "1.2.1"

--- a/config/cloudpaks/cp-shared/operators/templates/0050-sync-cluster-scoped-operators.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0050-sync-cluster-scoped-operators.yaml
@@ -20,9 +20,11 @@ spec:
             - name: RED_HAT_CERT_MANAGER_ENABLED
               value: "{{.Values.red_hat_cert_manager}}"
             - name: IBM_CERT_MANAGER_NAMESPACE
-              value: {{.Values.metadata.cert_manager_namespace}}
+              value: {{.Values.metadata.ibm_cert_manager_namespace}}
+            - name: IBM_CERT_MANAGER_OPERATOR_GROUP
+              value: {{.Values.metadata.ibm_cert_manager_operator_group}}
             - name: IBM_CERT_MANAGER_CHANNEL
-              value: {{.Values.metadata.cert_manager_channel}}
+              value: {{.Values.metadata.ibm_cert_manager_channel}}
           command:
             - /bin/sh
             - -c
@@ -48,7 +50,7 @@ spec:
               apiVersion: operators.coreos.com/v1
               kind: OperatorGroup
               metadata:
-                name: ibm-cert-manager
+                name: ${IBM_CERT_MANAGER_OPERATOR_GROUP:?}
                 namespace: ${IBM_CERT_MANAGER_NAMESPACE:?}
               spec:
                 upgradeStrategy: Default

--- a/config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0100-rh-cert-manager-operator-group.yaml
@@ -6,10 +6,10 @@ kind: OperatorGroup
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "100"
-  name: cert-manager-operator
-  namespace: cert-manager-operator
+  name: {{.Values.metadata.redhat_cert_manager_operator_group}}
+  namespace: {{.Values.metadata.redhat_cert_manager_namespace}}
 spec:
   targetNamespaces:
-    - cert-manager-operator
+    - {{.Values.metadata.redhat_cert_manager_namespace}}
   upgradeStrategy: Default
 {{- end }}

--- a/config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0110-rh-cert-manager-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "110"
   name: openshift-cert-manager-operator
-  namespace: cert-manager-operator
+  namespace: {{.Values.metadata.redhat_cert_manager_namespace}}
 spec:
   channel: stable-v1
   installPlanApproval: Automatic

--- a/config/cloudpaks/cp-shared/operators/values.yaml
+++ b/config/cloudpaks/cp-shared/operators/values.yaml
@@ -2,8 +2,11 @@
 red_hat_cert_manager: false
 metadata:
   argocd_namespace: openshift-gitops
-  cert_manager_namespace: ibm-cert-manager
-  cert_manager_channel: v4.2
+  ibm_cert_manager_channel: v4.2
+  ibm_cert_manager_namespace: ibm-cert-manager
+  ibm_cert_manager_operator_group: ibm-cert-manager-operator-group
+  redhat_cert_manager_namespace: cert-manager-operator
+  redhat_cert_manager_operator_group: cert-manager-operator-group
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller
 online_catalog_source_priority: -1

--- a/config/cloudpaks/cp4a/operators/values.yaml
+++ b/config/cloudpaks/cp4a/operators/values.yaml
@@ -1,8 +1,6 @@
 ---
 metadata:
   argocd_app_namespace: ibm-cloudpaks
-  cert_manager_namespace: ibm-cert-manager
-  cert_manager_channel: v4.2
 red_hat_cert_manager: false
 serviceaccount:
   argocd_application_controller: openshift-gitops-argocd-application-controller


### PR DESCRIPTION
closes: #313

Description of changes:
- Parameterization of operator group for IBM Cert Manager
- Parameterization of operator group for Red Hat Cert Manager
- Delete unused parameters related to cert manager in cp4ba project.

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH                                    TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd                           313-cert-opgroup
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp-shared       313-cert-opgroup
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp-shared/operators    313-cert-opgroup
openshift-gitops/cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-apic      313-cert-opgroup
openshift-gitops/cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/argocd-cloudpaks/cp4i            313-cert-opgroup
openshift-gitops/cp4i-mq              https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-mq        313-cert-opgroup
openshift-gitops/cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-platform  313-cert-opgroup
openshift-gitops/cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops.git  config/cloudpaks/cp4i/install-prereqs   313-cert-opgroup
```