### PR TITLE
feat: Support Power processor architecture for CP4I deployment

### DIFF
--- a/config/argocd-cloudpaks/cp-shared/Chart.yaml
+++ b/config/argocd-cloudpaks/cp-shared/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.5
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.3.4"
+appVersion: "1.4.0"

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-config-map.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-common-service-maps.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4a-config-map.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE

--- a/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
+++ b/config/argocd-cloudpaks/cp-shared/templates/0050-sync-cp4s-config-map.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/config/argocd-cloudpaks/cp4i/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4i/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4i/templates/0050-presync-adjust-app-config.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0050-presync-adjust-app-config.yaml
@@ -5,14 +5,14 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/sync-wave: "50"
-  name: presync-cp4i-storage-classes
+  name: presync-cp4i-config
   namespace: {{.Values.metadata.argocd_namespace}}
 spec:
   template:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_APP_NAME
@@ -45,15 +45,35 @@ spec:
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               && "${argo_cmd}" app set "${ARGOCD_APP_NAME}" \
                   --helm-set-string storageclass.rwo="${storage_class_rwo}" \
                   --helm-set-string storageclass.rwx="${storage_class_rwx}" \
               && echo "INFO: ${ARGOCD_APP_NAME} successfully updated storage classes." \
+              && if [ "${linux_arch}" == "ppc64le" ]; then
+                     "${argo_cmd}" app set "${ARGOCD_APP_NAME}" \
+                         --helm-set-string modules.apic="false"
+                 fi \
+              && echo "INFO: ${ARGOCD_APP_NAME} successfully updated modules." \
               || result=1
 
               echo "INFO: Application ${ARGOCD_APP_NAME} current parameters:"

--- a/config/argocd-cloudpaks/cp4i/templates/0310-sync-check-all-csvs.yaml
+++ b/config/argocd-cloudpaks/cp4i/templates/0310-sync-check-all-csvs.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: TARGET_NAMESPACE

--- a/config/cloudpaks/cp-shared/operators/templates/0050-sync-cluster-scoped-operators.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0050-sync-cluster-scoped-operators.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE
@@ -67,11 +67,22 @@ spec:
                 source: ibm-operator-catalog
                 sourceNamespace: openshift-marketplace
               EOF
-                      sleep 10
-                      oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER_NAMESPACE:?} --for=CatalogSourcesUnhealthy=False \
-                      && oc wait Subscription.operators.coreos.com ibm-cert-manager-operator -n ${IBM_CERT_MANAGER_NAMESPACE:?} --for=jsonpath='state'="AtLatestKnown" \
-                      && echo "INFO: Successfully installed IBM Cert Manager." \
-                      || result=1
+
+                      while [ $SECONDS -lt 300 ]; do
+                          oc wait Subscription.operators.coreos.com ibm-cert-manager-operator \
+                              -n ${IBM_CERT_MANAGER_NAMESPACE:?} \
+                              --for=condition=CatalogSourcesUnhealthy=False \
+                          && oc wait Subscription.operators.coreos.com ibm-cert-manager-operator \
+                              -n ${IBM_CERT_MANAGER_NAMESPACE:?} \
+                              --for=jsonpath='{.status.state}'="AtLatestKnown" \
+                          && echo "INFO: Successfully installed IBM Cert Manager." \
+                          && result=0 \
+                          && break \
+                          || result=1
+
+                          echo "INFO: Waiting for the subscription to be ready."
+                          sleep 20
+                      done
                   else
                       echo "INFO: IBM Cert Manager already installed."
                       oc get Subscription.operators.coreos.com \

--- a/config/cloudpaks/cp4i/install-prereqs/templates/0050-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4i/install-prereqs/templates/0050-sync-prereqs.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE


### PR DESCRIPTION
Contributes to: #315

Description of changes:
- Change sync hook classes from `quay.io/openshift/origin-cli:latest` to `registry.redhat.io/openshift4/ose-cli:latest`, which has support for multi-arch images.
- Account for `argocd` CLI having different download URLs depending on processor architecture
- Disable API Connect on Power architecture (not supported)
- Fixed bug in waiting for the IBM Cert Manager subscription
- Various updates to the `gitops.sh` script used to validate PRs, but most importantly, considering the different download URLs for the `argocd` CLI.

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

