### PR TITLE
feat: Support Power processor arch for CP4BA

### DIFF
--- a/config/argocd-cloudpaks/cp4a/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4a/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.6.2
+appVersion: 0.6.3

--- a/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-prereq-config.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-prereq-config.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_APP_NAME
@@ -41,9 +41,24 @@ spec:
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               && "${argo_cmd}" app set "${ARGOCD_APP_NAME}" \

--- a/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-storage-classes.yaml
+++ b/config/argocd-cloudpaks/cp4a/templates/00-presync-adjust-storage-classes.yaml
@@ -11,15 +11,8 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "250m"
-            limits:
-              memory: "96Mi"
-              cpu: "300m"
           env:
             - name: ARGOCD_APP_NAME
               value: cp4a-app
@@ -54,9 +47,24 @@ spec:
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               || result=1

--- a/config/cloudpaks/cp4a/operators/Chart.yaml
+++ b/config/cloudpaks/cp4a/operators/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4a/operators/templates/0100-presync-prereqs.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/0100-presync-prereqs.yaml
@@ -12,15 +12,8 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "200m"
-            limits:
-              memory: "256Mi"
-              cpu: "250m"
           env:
             - name: ARGOCD_NAMESPACE
               value: openshift-gitops

--- a/config/cloudpaks/cp4a/operators/templates/0120-postsync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4a/operators/templates/0120-postsync-check-all-csvs.yaml
@@ -13,15 +13,8 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            requests:
-              memory: "192Mi"
-              cpu: "250m"
-            limits:
-              memory: "256Mi"
-              cpu: "400m"
           env:
             - name: TARGET_NAMESPACE
               value: "{{.Values.argocd_app_namespace}}"

--- a/tests/postbuild/cluster.sh
+++ b/tests/postbuild/cluster.sh
@@ -17,7 +17,7 @@ oc_cmd=$(type -p oc)
 
 : "${NEW_CLUSTER_TYPE:=fyre-quick-burn}"
 : "${WORKER_FLAVOR:=medium}"
-: "${OCP_VERSION:=4.14}"
+: "${OCP_VERSION:=4.12}"
 
 # In hours
 : "${CLUSTER_EXPIRATION:=12}"


### PR DESCRIPTION
Contributes to: #315

Description of changes:
- Change sync hook classes from `quay.io/openshift/origin-cli:latest` to `registry.redhat.io/openshift4/ose-cli:latest`, which has support for multi-arch images.
- Account for `argocd` CLI having different download URLs depending on processor architecture

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

