### PR TITLE
chore: Use multi-arch image

### DIFF
--- a/config/argocd-cloudpaks/cp4s/templates/00-presync-adjust-parameters.yaml
+++ b/config/argocd-cloudpaks/cp4s/templates/00-presync-adjust-parameters.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/config/cloudpaks/cp4s/templates/resources/100-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4s/templates/resources/100-sync-prereqs.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/config/cloudpaks/cp4s/templates/resources/220-openldap.yaml
+++ b/config/cloudpaks/cp4s/templates/resources/220-openldap.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: TARGET_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Contributes to: #315

Description of changes:
- Use multi-arch images for sync hooks

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

Note the "OutOfSync" issue, related to an outstanding bug between the CP4S operator and the spec of the license field in the `CP4SThreatManagement` CR, which is expected until CP4S fixes the issue (see below, where the operator keeps removing the license field from one location and creating it in another location.)

```
 argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                  TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                         315-power-cp4s
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared     315-power-cp4s
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators  315-power-cp4s
openshift-gitops/cp4s-all             https://kubernetes.default.svc  cp4s              default               OutOfSync  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4s                 315-power-cp4s
openshift-gitops/cp4s-app             https://kubernetes.default.svc  openshift-gitops  default               Synced     Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4s          315-power-cp4s
```

<img width="1352" alt="image" src="https://github.com/IBM/cloudpak-gitops/assets/3278623/cad622d6-7e19-4dd8-aa45-09f75bca41d1">
