### PR TITLE
chore: Use multi-arch images for CP4D

### DIFF
--- a/config/argocd-cloudpaks/cp4d/Chart.yaml
+++ b/config/argocd-cloudpaks/cp4d/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/argocd-cloudpaks/cp4d/templates/0000-presync-adjust-storage-classes.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/0000-presync-adjust-storage-classes.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_APP_NAME
@@ -37,21 +37,39 @@ spec:
 
               echo "INFO: Install Argo CLI."
               # Install it from cluster, not from Internet, so airgap scenarios still work
-              argo_route=openshift-gitops-server
-              argo_secret=openshift-gitops-cluster
+              argo_route="${ARGOCD_NAMESPACE}-server"
+              argo_secret="${ARGOCD_NAMESPACE}-cluster"
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              cpd_cli_arch=""
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+                  cpd_cli_arch=".${linux_arch}"
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               && "${argo_cmd}" app set "${ARGOCD_APP_NAME}" \
                   --helm-set-string storageclass.rwo="${storage_class_rwo}" \
                   --helm-set-string storageclass.rwx="${storage_class_rwx}" \
+                  --helm-set-string image_arch="${cpd_cli_arch}" \
               && echo "INFO: ${ARGOCD_APP_NAME} successfully updated storage classes." \
               || result=1
 

--- a/config/argocd-cloudpaks/cp4d/templates/0100-cp4d-app.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/0100-cp4d-app.yaml
@@ -26,10 +26,10 @@ spec:
           value: {{.Values.components}}
         - name: iam_integration
           value: "{{.Values.iam_integration}}"
+        - name: image_arch
+          value: {{.Values.image_arch}}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
-        - name: metadata.image_arch
-          value: {{.Values.metadata.image_arch}}
         - name: metadata.operators_namespace
           value: {{.Values.metadata.operators_namespace}}
         - name: metadata.operands_namespace

--- a/config/argocd-cloudpaks/cp4d/templates/0200-cp4d-platform-app.yaml
+++ b/config/argocd-cloudpaks/cp4d/templates/0200-cp4d-platform-app.yaml
@@ -22,10 +22,10 @@ spec:
           value: {{.Values.components}}
         - name: iam_integration
           value: "{{.Values.iam_integration}}"
+        - name: image_arch
+          value: {{.Values.image_arch}}
         - name: metadata.argocd_app_namespace
           value: {{.Values.metadata.argocd_app_namespace}}
-        - name: metadata.image_arch
-          value: {{.Values.metadata.image_arch}}
         - name: metadata.operators_namespace
           value: {{.Values.metadata.operators_namespace}}
         - name: metadata.operands_namespace

--- a/config/argocd-cloudpaks/cp4d/values.yaml
+++ b/config/argocd-cloudpaks/cp4d/values.yaml
@@ -18,6 +18,9 @@ storageclass:
 
 iam_integration: true
 
-image_arch: amd64
+# suffix for labels for the olm-v2 utils image
+image_arch: ""
+# image_arch: .s390x
+# image_arch: .ppc64le
 
 version: 4.8.0

--- a/config/cloudpaks/cp4d/Chart.yaml
+++ b/config/cloudpaks/cp4d/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4d/templates/0090-sync-cluster-setup.yaml
+++ b/config/cloudpaks/cp4d/templates/0090-sync-cluster-setup.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: configure-cluster
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           env:
             - name: PROJECT_CERT_MANAGER
               value: ibm-cert-manager
@@ -25,8 +25,6 @@ spec:
               value: {{.Values.version}}
             - name: COMPONENTS
               value: {{.Values.components}}
-            - name: IMAGE_ARCH
-              value: {{.Values.image_arch}}
           command:
             - /bin/bash
             - -c

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-olm.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-olm.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: install-olm
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           env:
             - name: PROJECT_CPD_INST_OPERATORS
               value: {{.Values.metadata.operators_namespace}}
@@ -44,6 +44,12 @@ spec:
                   echo "WARNING: Unable to login to the cluster."
                   exit 1
               }
+
+              # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=requirements-hardware#hardware-reqs__svc-power
+              linux_arch=$(uname -p)
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  COMPONENTS=${COMPONENTS/,rstudio/}
+              fi
 
               # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=services-creating-informix-scc
               echo "INFO: Creating custom security context constraints for services."

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-platform.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-platform.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: install-components
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           env:
             - name: PROJECT_CPD_INST_OPERANDS
               value: {{.Values.metadata.operands_namespace}}
@@ -34,6 +34,20 @@ spec:
               set -x
 
               result=0
+
+              export KUBECONFIG=/tmp/kubeconfig
+              api_url=$(oc get Infrastructure cluster -o jsonpath='{.status.apiServerURL}')
+              oc login "${api_url}" --token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" --insecure-skip-tls-verify \
+              || {
+                  echo "WARNING: Unable to login to the cluster."
+                  exit 1
+              }
+
+              # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=requirements-hardware#hardware-reqs__svc-power
+              linux_arch=$(uname -p)
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  COMPONENTS=${COMPONENTS/,rstudio/}
+              fi
 
               # https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=data-installing-cloud-pak
               echo "INFO: Installing components in a specialized installation." \

--- a/config/cloudpaks/cp4d/templates/0100-sync-install-zen-workaround.yaml
+++ b/config/cloudpaks/cp4d/templates/0100-sync-install-zen-workaround.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: patch-zen-database
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           env:
             - name: COMPONENTS
               value: {{.Values.components}}

--- a/config/cloudpaks/cp4d/templates/0401-postsync-certificates.yaml
+++ b/config/cloudpaks/cp4d/templates/0401-postsync-certificates.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           imagePullPolicy: IfNotPresent
           env:
             - name: PROJECT_CPD_INST_OPERANDS

--- a/config/cloudpaks/cp4d/templates/0402-postsync-integrate-iam.yaml
+++ b/config/cloudpaks/cp4d/templates/0402-postsync-integrate-iam.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: install-olm
-          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}"
+          image: "icr.io/cpopen/cpd/olm-utils-v2:{{.Values.version}}{{.Values.image_arch}}"
           env:
             - name: PROJECT_CPD_INST_OPERANDS
               value: {{.Values.metadata.operands_namespace}}


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Contributes to: #315

Description of changes:
- Use multi-arch images in argo cd sync hooks

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
argocd app list -l app.kubernetes.io/instance=cp4d-app
NAME                            CLUSTER                         NAMESPACE         PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                          TARGET
openshift-gitops/cp4d-app       https://kubernetes.default.svc  openshift-gitops  default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4d  315-power-cp4d
openshift-gitops/cp4d-platform  https://kubernetes.default.svc  cp4d              default  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4d         315-power-cp4d
```
