### PR TITLE
chore: Use multi-arch images for AIOps

### DIFF
--- a/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/Chart.yaml
@@ -13,7 +13,7 @@ description: Cloud Pak for AIOps - AI Manager
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.17.0
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/000-presync-adjust-parameters.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/000-presync-adjust-parameters.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE
@@ -40,16 +40,31 @@ spec:
 
               echo "INFO: Install Argo CLI."
               # Install it from cluster, not from Internet, so airgap scenarios still work
-              argo_route=openshift-gitops-server
-              argo_secret=openshift-gitops-cluster
+              argo_route="${ARGOCD_NAMESPACE}-server"
+              argo_secret="${ARGOCD_NAMESPACE}-cluster"
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               || result=1

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/230-postsync-certificates.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/resources/230-postsync-certificates.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: TARGET_NAMESPACE

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/030-sync-prereqs.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/030-sync-prereqs.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE

--- a/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/110-sync-check-all-csvs.yaml
+++ b/config/cloudpaks/cp4aiops/install-aimgr/templates/subscriptions/110-sync-check-all-csvs.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: TARGET_NAMESPACE

--- a/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
+++ b/config/cloudpaks/cp4aiops/install-ia/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4aiops/install-ia/templates/resources/000-presync-adjust-parameters.yaml
+++ b/config/cloudpaks/cp4aiops/install-ia/templates/resources/000-presync-adjust-parameters.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: config
-          image: quay.io/openshift/origin-cli:latest
+          image: registry.redhat.io/openshift4/ose-cli:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: ARGOCD_NAMESPACE
@@ -35,16 +35,31 @@ spec:
 
               echo "INFO: Install Argo CLI."
               # Install it from cluster, not from Internet, so airgap scenarios still work
-              argo_route=openshift-gitops-server
-              argo_secret=openshift-gitops-cluster
+              argo_route="${ARGOCD_NAMESPACE}-server"
+              argo_secret="${ARGOCD_NAMESPACE}-cluster"
 
               export HOME=/tmp
               argo_cmd="${HOME}/argocd"
               result=0
 
+              linux_arch=$(uname -p)
+              argocd_cli_arch=amd64
+              if [ "${linux_arch}" == "ppc64le" ] || [ "${linux_arch}" == "s390x" ]; then
+                  argocd_cli_arch=${linux_arch}
+              fi
+
               argo_url=$(oc get route ${argo_route} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.spec.host}') \
-              && curl -skL "${argo_url}/download/argocd-linux-amd64" -o "${argo_cmd}" \
-              && chmod 755 "${argo_cmd}" \
+              && cli_status=$(curl -skL "${argo_url}/download/argocd-linux-${argocd_cli_arch}" \
+                  -o "${argo_cmd}" \
+                  -w "%{http_code}") \
+              || result=1
+
+              if [ "${cli_status}" != "200" ]; then
+                  echo "ERROR: Unable to download argocd client."
+                  exit 2
+              fi
+
+              chmod 755 "${argo_cmd}" \
               && argo_pwd=$(oc get secret ${argo_secret} -n ${ARGOCD_NAMESPACE} -ojsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
               && "${argo_cmd}" login "${argo_url}" --username admin --password "${argo_pwd}" --insecure \
               || result=1


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Contributes to: #315

Description of changes:
- Use multi-arch images for Cloud Pak for AIOps

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                     TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                            315-power-cp4aiops
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared        315-power-cp4aiops
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators     315-power-cp4aiops
openshift-gitops/cp4aiops-aimgr       https://kubernetes.default.svc  cp4aiops          default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4aiops/install-aimgr  315-power-cp4aiops
openshift-gitops/cp4aiops-app         https://kubernetes.default.svc  cp4aiops          default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4aiops         315-power-cp4aiops
```

