### PR TITLE
chore: Update to CP4S 1.10.19

### DIFF
--- a/config/cloudpaks/cp4s/Chart.yaml
+++ b/config/cloudpaks/cp4s/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.10.15
+appVersion: 1.10.19

--- a/config/cloudpaks/cp4s/templates/resources/200-cp4s-threat-mgmt.yaml
+++ b/config/cloudpaks/cp4s/templates/resources/200-cp4s-threat-mgmt.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: isc.ibm.com/v1
+apiVersion: isc.ibm.com/v2
 kind: CP4SThreatManagement
 metadata:
   annotations:
@@ -8,7 +8,8 @@ metadata:
   name: threatmgmt
   namespace: "{{.Values.metadata.argocd_app_namespace}}"
 spec:
-  acceptLicense: true
+  license:
+    accept: true
   basicDeploymentConfiguration:
     adminUser: {{.Values.admin_user}}
     domain: cp4s.{{.Values.cluster_domain}}


### PR DESCRIPTION
contributes-to: #271

Description of changes:
- Updated CP4SThreatManagement to V2

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                  TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                         271-cp4s-v2
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared     271-cp4s-v2
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators  271-cp4s-v2
openshift-gitops/cp4s-all             https://kubernetes.default.svc  cp4s              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4s                 271-cp4s-v2
openshift-gitops/cp4s-app             https://kubernetes.default.svc  openshift-gitops  default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4s          271-cp4s-v2
```