### PR TITLE
Update rhacm.md add --helm-set repoURL on argoCD-control-plane create

### DIFF
--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -138,6 +138,7 @@ Consider adding this application to your cluster if your organization does not h
          --dest-server https://kubernetes.default.svc \
          --repo ${gitops_url:?} \
          --path config/argocd \
+         --helm-set repoURL=${gitops_url:?} \
          --helm-set-string targetRevision="${gitops_branch}" \
          --revision ${gitops_branch:?} \
          --sync-policy automated \


### PR DESCRIPTION
Added missing --helm-set repoURL line so that it works if you add your own repo. The argo cd app and rhacm_control plane worked without this variable but if I used the base IBM/cloudpak-gitops/ repo but I was getting permissions error if I tried to install from my "slipsibm/cloudpak-gitops" repo

Contributes to: #332 

Description of changes:
-added line for --helm-set repoURL
- <change 2 ... >

