### PR TITLE
fix: Update CP4I 2023.4.1 versions

### DIFF
--- a/config/cloudpaks/cp-shared/operators/templates/0050-catalog-source-foundation-services.yaml
+++ b/config/cloudpaks/cp-shared/operators/templates/0050-catalog-source-foundation-services.yaml
@@ -6,9 +6,65 @@ metadata:
   name: cloud-native-postgresql-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-cloud-native-postgresql-4.18.0
+  displayName: ibm-cloud-native-postgresql-4.22.0+20240307.065137.1505
   publisher: IBM
-  image: icr.io/cpopen/ibm-cpd-cloud-native-postgresql-operator-catalog@sha256:c96aa2e6bce92f2e5e4874116cf1cc1cdd60676499cd04ab1631462b8b883357
+  image: icr.io/cpopen/ibm-cpd-cloud-native-postgresql-operator-catalog@sha256:3a44f3e7f01e4eb72d192008f1502777dc10751b68e40da2e1d38d23f2907ce7
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m0s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-cs-iam-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-cs-iam-4.5.0
+  publisher: IBM
+  image: icr.io/cpopen/ibm-iam-operator-catalog@sha256:dd64034fb63a04cb380e81b25d54708bb96080a1b6417d9d068b6f4a1904bebc
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m0s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-cs-install-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-cs-install-4.6.0
+  publisher: IBM
+  image: icr.io/cpopen/ibm-cs-install-catalog@sha256:1eb2d3fe9fdbcf1c413de123cd62344e72b4034054b02f08e351839d3f1dda9c
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m0s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-events-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-events-operator-5.0.0
+  publisher: IBM
+  image: icr.io/cpopen/ibm-events-operator-catalog@sha256:2267b5677e10a25aa6522d2d60ef85e8be5d65bb32b8c4b82afcf854440e6d34
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m0s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-zen-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-zen-3.1.3
+  publisher: IBM
+  image: icr.io/cpopen/ibm-zen-operator-catalog@sha256:320db8cf76a866450e1afb76066545aa04675b7f91246587d76eaf17bd92b5e0
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -20,9 +76,9 @@ metadata:
   name: opencloud-operators
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-cp-common-services-4.3.0
+  displayName: ibm-cp-common-services-4.6.0
   publisher: IBM
-  image: icr.io/cpopen/ibm-common-service-catalog@sha256:5f2ada10db36dd609913f806fc44051186a1b719a0c1e04edfae5a6807b0eb26
+  image: icr.io/cpopen/ibm-common-service-catalog@sha256:491916cce0da256b7b15d7cb1dc7fdd30465a366a5d8796d0dee898c99cde1a3
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/config/cloudpaks/cp4i/install-mq/Chart.yaml
+++ b/config/cloudpaks/cp4i/install-mq/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4i/install-mq/templates/0050-catalog-source-mq.yaml
+++ b/config/cloudpaks/cp4i/install-mq/templates/0050-catalog-source-mq.yaml
@@ -8,9 +8,9 @@ metadata:
   name: ibmmq-operator-catalogsource
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-mq-3.0.0
+  displayName: ibm-mq-3.1.2
   publisher: IBM
-  image: icr.io/cpopen/ibm-mq-operator-catalog@sha256:99b43b78e103fa18ea91827286c865219493a056e6f002096558a2dd1655c9b7
+  image: icr.io/cpopen/ibm-mq-operator-catalog@sha256:9c9211c1b42caba5ac2dff299945b22649ce600f3f0994077af6d440e4594046
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/config/cloudpaks/cp4i/install-mq/templates/0100-subscription-mq.yaml
+++ b/config/cloudpaks/cp4i/install-mq/templates/0100-subscription-mq.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ibm-mq-ibm-operator
   namespace: {{.Values.metadata.argocd_app_namespace}}
 spec:
-  channel: v3.0
+  channel: v3.1
   installPlanApproval: Automatic
   name: ibm-mq
   source: ibmmq-operator-catalogsource

--- a/config/cloudpaks/cp4i/install-mq/templates/0210-queue-manager.yaml
+++ b/config/cloudpaks/cp4i/install-mq/templates/0210-queue-manager.yaml
@@ -8,7 +8,7 @@ metadata:
   name: case-queues-1-qmgr
   namespace: {{.Values.argocd_app_namespace}}
 spec:
-  version: 9.3.4.0-r1
+  version: 9.3.5.0-r2
   license:
     accept: true
     # http://ibm.biz/BdqvCF

--- a/config/cloudpaks/cp4i/install-platform/Chart.yaml
+++ b/config/cloudpaks/cp4i/install-platform/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4i/install-platform/templates/0050-catalog-source-platform-navigator.yaml
+++ b/config/cloudpaks/cp4i/install-platform/templates/0050-catalog-source-platform-navigator.yaml
@@ -8,9 +8,9 @@ metadata:
   name: ibm-integration-platform-navigator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-integration-platform-navigator-7.2.0
+  displayName: ibm-integration-platform-navigator-7.2.4
   publisher: IBM
-  image: icr.io/cpopen/ibm-integration-platform-navigator-catalog@sha256:6696f54af1d2cc0a97d2014fd56538e937299a693a171d0424a535027c942149
+  image: icr.io/cpopen/ibm-integration-platform-navigator-catalog@sha256:71d5b07bb009e9b111a5755c191a6dd3d5a80c24f371f93d25d30a22d6339a35
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/config/cloudpaks/cp4i/install-prereqs/Chart.yaml
+++ b/config/cloudpaks/cp4i/install-prereqs/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/cloudpaks/cp4i/install-prereqs/values.yaml
+++ b/config/cloudpaks/cp4i/install-prereqs/values.yaml
@@ -9,4 +9,4 @@ storageclass:
   rwo: ocs-storagecluster-ceph-rbd
   rwx: ocs-storagecluster-cephfs
 spec:
-  ibm_common_service_operator_channel: v4.3
+  ibm_common_service_operator_channel: v4.6


### PR DESCRIPTION
closes: #334

Description of changes:
- Update CatalogSources
- Update Subscriptions
- Update Operands

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```
 argocd app list
NAME                                  CLUSTER                         NAMESPACE         PROJECT               STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                    PATH                                    TARGET
openshift-gitops/argo-app             https://kubernetes.default.svc  openshift-gitops  argocd-control-plane  Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd                           main
openshift-gitops/cp-shared-app        https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp-shared       cp4i-2023-4-update
openshift-gitops/cp-shared-operators  https://kubernetes.default.svc  ibm-cloudpaks     default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp-shared/operators    cp4i-2023-4-update
openshift-gitops/cp4i-apic            https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-apic      cp4i-2023-4-update
openshift-gitops/cp4i-app             https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/argocd-cloudpaks/cp4i            cp4i-2023-4-update
openshift-gitops/cp4i-platform        https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-platform  cp4i-2023-4-update
openshift-gitops/cp4i-prereqs         https://kubernetes.default.svc  cp4i              default               Synced  Healthy  Auto-Prune  <none>      https://github.com/IBM/cloudpak-gitops  config/cloudpaks/cp4i/install-prereqs   cp4i-2023-4-update

```
