### PR TITLE
feat:Upgrade RHACM to 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You may decide to include one or more of these `Application` objects to the targ
 
 [IBM Cloud® Paks](https://www.ibm.com/cloud/paks) help organizations build, modernize, and manage applications securely across any cloud.
 
-The supported deployment mechanisms for Cloud Paks are documented in their respective [documentation pages](https://www.ibm.com/docs/en/cloud-paks) and typically included a UI-based deployment through the Operator Hub page or, in some cases, scripted alternatives based on command-line interfaces.
+The supported deployment mechanisms for Cloud Paks are documented in their respective [documentation pages](https://www.ibm.com/docs/en/cloud-paks) and typically include a UI-based deployment through the Operator Hub page or, in some cases, scripted alternatives based on command-line interfaces.
 
 Supported versions:
 

--- a/config/rhacm/cloudpaks/templates/placement-argocd.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-argocd.yaml
@@ -1,7 +1,7 @@
 {{- range tuple "cp4a" "cp4aiops" "cp4d" "cp4i" "cp4s" }}
 ---
 apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+kind: Placement
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "200"
@@ -29,7 +29,7 @@ metadata:
   namespace: policy
 placementRef:
   name: openshift-gitops-{{.}}
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: openshift-gitops-installed
@@ -45,7 +45,7 @@ metadata:
   namespace: policy
 placementRef:
   name: openshift-gitops-{{.}}
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: openshift-gitops-argo-app

--- a/config/rhacm/cloudpaks/templates/placement-cloudpaks.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-cloudpaks.yaml
@@ -1,7 +1,7 @@
 {{- range tuple "cp4a" "cp4aiops" "cp4d" "cp4i" "cp4s" }}
 ---
 apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+kind: Placement
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "200"
@@ -26,7 +26,7 @@ metadata:
   namespace: policy
 placementRef:
   name: placement-openshift-gitops-cloudpaks-{{.}}
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: openshift-gitops-cloudpaks-{{.}}

--- a/config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-cp-shared.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: policy
 placementRef:
   name: openshift-gitops-{{.}}
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: openshift-gitops-cloudpaks-cp-shared

--- a/config/rhacm/cloudpaks/templates/placement-gitops-policy.yaml
+++ b/config/rhacm/cloudpaks/templates/placement-gitops-policy.yaml
@@ -2,7 +2,7 @@
 {{- range tuple "cp4a" "cp4aiops" "cp4d" "cp4i" "cp4s" }}
 ---
 apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+kind: Placement
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "200"
@@ -27,7 +27,7 @@ metadata:
   namespace: "{{ $argocd_namespace }}"
 placementRef:
   name: placement-openshift-gitops-entitlement-key-{{.}}
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: cloudpak-entitlement-key

--- a/config/rhacm/seeds/Chart.yaml
+++ b/config/rhacm/seeds/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.9.1
+appVersion: 2.10.3

--- a/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
+++ b/config/rhacm/seeds/templates/0100-rhacm-subscription.yaml
@@ -8,7 +8,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
 spec:
-  channel: release-2.9
+  channel: release-2.10
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators

--- a/config/rhacm/seeds/templates/0200-gitops-managed-cluster-set.yaml
+++ b/config/rhacm/seeds/templates/0200-gitops-managed-cluster-set.yaml
@@ -1,4 +1,4 @@
-# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/applications/managing-applications#gitops-config
+# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/applications/managing-applications#gitops-config
 ---
 apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet

--- a/config/rhacm/seeds/templates/0200-placement-gitops.yaml
+++ b/config/rhacm/seeds/templates/0200-placement-gitops.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+kind: Placement
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/config/rhacm/seeds/templates/0200-placement-ocp.yaml
+++ b/config/rhacm/seeds/templates/0200-placement-ocp.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+kind: Placement
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/config/rhacm/seeds/templates/0300-binding-gitops.yaml
+++ b/config/rhacm/seeds/templates/0300-binding-gitops.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: policy
 placementRef:
   name: all-openshift-gitops-rhacm
-  kind: PlacementRule
+  kind: Placement
   apiGroup: apps.open-cluster-management.io
 subjects:
   - name: openshift-gitops-installed

--- a/config/rhacm/seeds/templates/9000-post-multi-cluster-engine.yaml
+++ b/config/rhacm/seeds/templates/9000-post-multi-cluster-engine.yaml
@@ -1,4 +1,4 @@
-# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html-single/clusters/index#hosting-service-cluster-configure-aws
+# https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html-single/clusters/index#hosting-service-cluster-configure-aws
 ---
 apiVersion: batch/v1
 kind: Job

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,7 +36,7 @@
 
 - Cluster storage configured with storage classes supporting both [RWO and RWX storage](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).
 
-  The applications were tested with [OpenShift Container Storage](https://docs.openshift.com/container-platform/4.8/storage/persistent_storage/persistent-storage-ocs.html), [Rook Ceph](https://github.com/rook/rook), [AWS EFS](https://aws.amazon.com/efs/), and the built-in file storage in ROKS classic clusters.
+  The applications were tested with [OpenShift Data Foundation](https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation), [Rook Ceph](https://github.com/rook/rook), [AWS EFS](https://aws.amazon.com/efs/), and the built-in file storage in ROKS classic clusters.
 
 - [An entitlement key to the IBM Entitled Registry](#obtain-an-entitlement-key)
 

--- a/docs/rhacm.md
+++ b/docs/rhacm.md
@@ -39,7 +39,7 @@ This repository contains governance policies and placement rules for Argo CD and
 
 - Adequate worker node capacity in the cluster for RHACM to be installed.
 
-  Refer to the [RHACM documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/install/installing#sizing-your-cluster) to determine the required capacity for the cluster.
+  Refer to the [RHACM documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing#sizing-your-cluster) to determine the required capacity for the cluster.
 
 - [An entitlement key to the IBM Entitled Registry](#obtain-an-entitlement-key). This key is required in the RHACM cluster to be copied to the managed clusters when a cluster matches a policy to install a Cloud Pak.
 
@@ -244,7 +244,7 @@ Labels:
 - `gitops-branch` + `cp4i`: Placement for Cloud Pak for Integration.
 - `gitops-branch` + `cp4s`: Placement for Cloud Pak for Security.
 - `gitops-branch` + `cp4aiops`: Placement for Cloud Pak for AIOps.
-- `gitops-remote` + `true`: Assign cluster to the `gitops-cluster` cluster-set, registering it to the [GitOps Cluster](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/applications/managing-applications#gitops-config).
+- `gitops-remote` + `true`: Assign cluster to the `gitops-cluster` cluster-set, registering it to the [GitOps Cluster](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/applications/managing-applications#gitops-config).
 
 Values for each label:
 


### PR DESCRIPTION
Signed-off-by: Denilson Nastacio <dnastaci@us.ibm.com>

Contributes to: #337

Description of changes:
- Updates RHACM subscription to 2.10
- Replaces all deprecated references to "PlacementRule" with "Placement"

Output of `argocd app list` command or screenshot of the Argo CD Application synchronization window showing successful application of changes in this branch.

```txt
GROUP        KIND         NAMESPACE                NAME                     STATUS     HEALTH   HOOK  MESSAGE
argoproj.io  AppProject   openshift-gitops         rhacm-control-plane      Synced                    appproject.argoproj.io/rhacm-control-plane unchanged
             Namespace    open-cluster-management  open-cluster-management  Succeeded  Synced         namespace/open-cluster-management unchanged
argoproj.io  Application  openshift-gitops         rhacm-app                Synced                    application.argoproj.io/rhacm-app configured
argoproj.io  Application  openshift-gitops         rhacm-seeds              Synced     Healthy        application.argoproj.io/rhacm-seeds configured
argoproj.io  Application  openshift-gitops         rhacm-cloudpaks          Synced     Healthy        application.argoproj.io/rhacm-cloudpaks created
```

